### PR TITLE
Add pinned, audible, muted, and status fields to tabs_context

### DIFF
--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -281,6 +281,10 @@ async function handleTabsQuery() {
         url: t.url || "",
         title: t.title || "",
         active: t.active,
+        pinned: t.pinned || false,
+        audible: t.audible || false,
+        muted: t.mutedInfo ? t.mutedInfo.muted : false,
+        status: t.status || "complete",
         windowId: t.windowId,
         index: t.index,
     }));


### PR DESCRIPTION
## Summary
- `tabs_context` currently returns only `id`, `url`, `title`, `active`, `windowId`, and `index` from `browser.tabs.query`
- Safari's WebExtensions API exposes additional useful tab state that is being dropped in the map
- Add `pinned`, `audible`, `muted` (flattened from `mutedInfo.muted`), and `status` to the `handleTabsQuery` response

## Motivation
These fields are useful for tab management tooling built on top of MCPSafari:
- **`pinned`** — distinguish pinned tabs from regular tabs
- **`audible`** — identify tabs currently playing audio
- **`muted`** — know if a tab has been muted
- **`status`** — `"loading"` vs `"complete"`, useful for detecting stale or failed tabs

All four properties are supported in Safari 15+.

## Change
Four one-line additions in `handleTabsQuery()` in `background.js`. No breaking changes — only additive fields in the response.