### PR TITLE
docs: fix Claude Code configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,13 @@ Then enable the extension in **Safari > Settings > Extensions > MCPSafari Extens
 
 ### Claude Code
 
-Add to your MCP settings (`.claude/settings.json` or project-level):
+Register the server with the Claude Code CLI (user scope, available in every project):
+
+```bash
+claude mcp add --scope user mcp-safari mcp-safari
+```
+
+Or, to scope it to a single repo, create `.mcp.json` at the project root:
 
 ```json
 {
@@ -134,6 +140,10 @@ Add to your MCP settings (`.claude/settings.json` or project-level):
   }
 }
 ```
+
+Verify with `claude mcp list` — you should see `mcp-safari — ✓ Connected`.
+
+> **Note:** Claude Code's CLI does not read `mcpServers` from `~/.claude/settings.json` — that's the Claude Desktop format. Pasting the JSON snippet above into `settings.json` is silently ignored (no error, no registration), and the Safari extension will appear stuck at "disconnected" because the server is never spawned. Use `claude mcp add` or `.mcp.json` as shown above.
 
 ### Claude Desktop
 


### PR DESCRIPTION
## Problem

The **Configuration → Claude Code** section of the README tells users to add this to `.claude/settings.json`:

```json
{
  "mcpServers": {
    "mcp-safari": { "command": "mcp-safari" }
  }
}
```

The Claude Code **CLI** doesn't read `mcpServers` from `settings.json` — that's the Claude **Desktop** format. The key is accepted silently but never consumed. Following the current README leaves the server unregistered, never spawned, and the Safari extension stuck at "disconnected" indefinitely — with no error surfaced anywhere.

This sends users chasing phantom causes (extension not enabled, port mismatch, Safari permissions, etc.) before realizing the config itself did nothing.

## Repro

1. macOS 14+, Safari 17+
2. `brew install --cask epistates/tap/mcp-safari`
3. Launch `MCPSafari.app`, enable extension in Safari → Settings → Extensions (popup confirms "extension is currently on")
4. Paste the README's Claude Code snippet into `~/.claude/settings.json`
5. Restart Claude Code

**Expected:** `claude mcp list` shows `mcp-safari — ✓ Connected`; extension flips to connected.

**Actual:**
- `claude mcp list` has no `mcp-safari` entry
- `pgrep -fl mcp-safari` → empty
- `lsof -i :8089` → empty
- Extension popup stays red/disconnected
- No `mcp__mcp-safari__*` tools available in the Claude Code session

## Root cause

Claude Code (CLI) maintains its MCP registry in `~/.claude.json`, populated either by `claude mcp add` or by a project-level `.mcp.json`. The `~/.claude/settings.json` schema doesn't honor `mcpServers`.

## Fix

Replace the snippet with the CLI command, document the `.mcp.json` alternative for project scope, and add a note explicitly calling out the silent-failure mode (so the old, cached instructions don't keep biting users).

Claude Desktop section left unchanged — that one is correct.

## Verification

After the new instructions:
```
$ claude mcp add --scope user mcp-safari mcp-safari
Added stdio MCP server mcp-safari with command: mcp-safari to user config

$ claude mcp list
mcp-safari: mcp-safari  - ✓ Connected
```

Safari extension popup immediately flips to "Connected", 23 `mcp__mcp-safari__*` tools load into the Claude Code session.