### PR TITLE
Fix javascript_tool expression results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+- `javascript_tool` now returns values for bare expression inputs while preserving multi-statement function-body behavior.
+
 ## [0.2.6] - 2026-05-04
 ### Build
 - Updated source builds for Swift 6.3 and pinned the MCP Swift SDK to a Swift 6.3-compatible upstream revision.

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -460,7 +460,13 @@ async function handleJavaScript(params) {
         target: { tabId },
         func: (code) => {
             try {
-                const fn = new Function(`return (async () => { ${code} })()`);
+                const expressionCode = String(code).trim().replace(/;+$/, "");
+                let fn;
+                try {
+                    fn = new Function(`return (async () => (${expressionCode}))()`);
+                } catch (_) {
+                    fn = new Function(`return (async () => { ${code} })()`);
+                }
                 return fn();
             } catch (e) {
                 return { __error: e.message };

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -302,7 +302,7 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "javascript_tool",
-                description: "Execute JS in page context. Returns result.",
+                description: "Execute JS in page context. Returns expression results.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ For ports outside the default range, add them manually in the extension popup or
 
 | Tool | Description |
 |------|-------------|
-| `javascript_tool` | Execute arbitrary JS in the page context |
+| `javascript_tool` | Execute arbitrary JS in the page context and return expression results |
 
 ### Debugging
 


### PR DESCRIPTION
## Summary

- Return values for bare-expression `javascript_tool` inputs.
- Preserve existing async function-body behavior for multi-statement code.
- Update the tool description, README, and changelog.

## Verification

- Node behavior harness covering:
  - bare expression
  - trailing-semicolon expression
  - object literal expression
  - `await` expression
  - explicit `return`
  - multi-statement body
  - body without return
- `node --check "MCPSafari/MCPSafari Extension/Resources/background.js"`
- `swift test`
- `xcodebuild -project MCPSafari.xcodeproj -scheme MCPSafari -configuration Debug build CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO`

Fixes #8.
