### PR TITLE
Fix launch crash in extension state callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Bug Fixes
+- Fixed a host app launch crash when SafariServices returned extension state on a non-main XPC callback queue.
 
 ## [0.2.7] - 2026-05-06
 ### Added

--- a/MCPSafari/MCPSafari/ViewController.swift
+++ b/MCPSafari/MCPSafari/ViewController.swift
@@ -9,7 +9,7 @@ import Cocoa
 import SafariServices
 import WebKit
 
-let extensionBundleIdentifier = "com.epistates.MCPSafari.Extension"
+nonisolated let extensionBundleIdentifier = "com.epistates.MCPSafari.Extension"
 
 class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
 
@@ -26,20 +26,28 @@ class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHan
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: extensionBundleIdentifier) { (state, error) in
+        Self.updateExtensionStateDisplay(for: webView)
+    }
+
+    private nonisolated static func updateExtensionStateDisplay(for webView: WKWebView) {
+        let completion: @Sendable (SFSafariExtensionState?, Error?) -> Void = { (state, error) in
             guard let state = state, error == nil else {
                 // Insert code to inform the user that something went wrong.
                 return
             }
 
+            let isEnabled = state.isEnabled
+
             DispatchQueue.main.async {
                 if #available(macOS 13, *) {
-                    webView.evaluateJavaScript("show(\(state.isEnabled), true)")
+                    webView.evaluateJavaScript("show(\(isEnabled), true)")
                 } else {
-                    webView.evaluateJavaScript("show(\(state.isEnabled), false)")
+                    webView.evaluateJavaScript("show(\(isEnabled), false)")
                 }
             }
         }
+
+        SFSafariExtensionManager.getStateOfSafariExtension(withIdentifier: extensionBundleIdentifier, completionHandler: completion)
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {


### PR DESCRIPTION
## Summary

Fixes an app-host launch crash on newer Swift/macOS runtimes when `SFSafariExtensionManager.getStateOfSafariExtension` calls its completion on SafariServices’ XPC queue.

The app target uses Swift 6 default actor isolation. The existing closure in `ViewController.webView(_:didFinish:)` can trip Swift’s executor isolation check before it reaches the `DispatchQueue.main.async` UI update.

This patch moves the Safari extension state lookup into a `nonisolated static` helper, uses a concrete `@Sendable` completion, captures `state.isEnabled` off the callback queue, and only hops to the main queue for `webView.evaluateJavaScript`.

Also adds an `Unreleased` changelog entry for the launch-crash fix.

## Verification

```sh
xcodebuild -project MCPSafari/MCPSafari.xcodeproj \
  -scheme MCPSafari \
  -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  build CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO

git diff --check
```

Also verified locally during investigation with a signed Debug app: the host app reached the normal extension-status UI instead of crashing.
