### PR TITLE
Fix WebSocket listener startup with loopback endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Bug Fixes
 - Fixed a host app launch crash when SafariServices returned extension state on a non-main XPC callback queue.
+- Fixed WebSocket listener startup on systems that reject setting the local port twice.
 
 ## [0.2.7] - 2026-05-06
 ### Added

--- a/MCPServer/Sources/mcp-safari/WebSocketBridge.swift
+++ b/MCPServer/Sources/mcp-safari/WebSocketBridge.swift
@@ -138,7 +138,7 @@ actor WebSocketBridge {
             guard let nwPort = NWEndpoint.Port(rawValue: tryPort) else { continue }
 
             do {
-                let newListener = try NWListener(using: Self.makeWebSocketParameters(for: nwPort), on: nwPort)
+                let newListener = try NWListener(using: Self.makeWebSocketParameters(for: nwPort))
                 self.listener = newListener
                 self.port = tryPort
 


### PR DESCRIPTION
## Summary

Fixes WebSocket listener startup on systems that reject setting the local port twice.

`WebSocketBridge.start()` currently creates parameters with:

```swift
params.requiredLocalEndpoint = .hostPort(host: .ipv4(.loopback), port: port)
```

and then also creates the listener with:

```swift
NWListener(using: params, on: nwPort)
```

On macOS 26.4.1 this can fail with:

```text
nw_listener_copy_parameters_with_port Local endpoint has port set, cannot override to 8089: 127.0.0.1:8089
```

When that happens, the server never listens on any auto-scan port, so the Safari extension cannot connect.

This patch keeps the loopback endpoint binding in `requiredLocalEndpoint` and removes the duplicate `on: nwPort` argument.

Also adds an `Unreleased` changelog entry.

## Verification

```sh
cd MCPServer
swift test
.build/arm64-apple-macosx/debug/MCPSafari --port 8123
```

The startup probe logs:

```text
WebSocket server listening on port 8123
```

Also verified during investigation with the installed local test binary: the extension could connect once the listener and auth fixes were installed.
