### PR TITLE
Fix authenticated Safari extension autoconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Bug Fixes
 - Fixed a host app launch crash when SafariServices returned extension state on a non-main XPC callback queue.
+- Fixed Safari extension autoconnect for authenticated MCP servers by loading tokens from the real macOS home directory and requiring auth before reporting a port connected.
 
 ## [0.2.7] - 2026-05-06
 ### Added

--- a/MCPSafari/MCPSafari Extension/MCPSafari Extension.entitlements
+++ b/MCPSafari/MCPSafari Extension/MCPSafari Extension.entitlements
@@ -4,6 +4,10 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
+	<array>
+		<string>/.config/mcp-safari/</string>
+	</array>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
 </dict>

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -48,10 +48,10 @@ function connectToPort(port) {
     const conn = ensurePort(port);
     if (conn.ws && (conn.ws.readyState === WebSocket.OPEN || conn.ws.readyState === WebSocket.CONNECTING)) return;
 
-    // Security: auto-scan ports require auth token to prevent rogue process connections.
-    // Manual ports (user explicitly added) are trusted without auth.
+    // Security: every server instance requires its per-port auth token.
     const authToken = authTokensByPort.get(port) || legacyAuthToken;
-    if (!conn.manual && isAutoScanPort(port) && !authToken) {
+    if (!authToken) {
+        conn.state = "disconnected";
         return; // Skip — can't verify server identity without auth
     }
 
@@ -60,25 +60,11 @@ function connectToPort(port) {
     const socket = new WebSocket(wsUrl);
     conn.ws = socket;
 
-    // Auto-scan ports always require auth; manual ports use auth if available
-    const requireAuth = !conn.manual && isAutoScanPort(port);
-    let pendingAuth = !!authToken;
+    let pendingAuth = true;
 
     socket.onopen = () => {
-        conn.lastConnected = Date.now();
-        if (authToken) {
-            socket.send(JSON.stringify({ auth: authToken }));
-            console.log(`[MCPSafari:${port}] Sent auth token`);
-        } else if (!requireAuth) {
-            // Manual port, no auth available — connect directly
-            conn.state = "connected";
-            conn.attempts = 0;
-            console.log(`[MCPSafari:${port}] Connected (manual, no auth)`);
-        } else {
-            // Should not reach here due to guard above, but be safe
-            console.error(`[MCPSafari:${port}] Auto-scan port requires auth`);
-            socket.close();
-        }
+        socket.send(JSON.stringify({ auth: authToken }));
+        console.log(`[MCPSafari:${port}] Sent auth token`);
     };
 
     socket.onmessage = async (event) => {
@@ -87,6 +73,7 @@ function connectToPort(port) {
             try {
                 const msg = JSON.parse(event.data);
                 if (msg.auth === "ok") {
+                    conn.lastConnected = Date.now();
                     conn.state = "connected";
                     conn.attempts = 0;
                     console.log(`[MCPSafari:${port}] Authenticated`);
@@ -145,6 +132,17 @@ function connectAll() {
     }
 }
 
+function reconnectKnownPorts() {
+    for (const [port, conn] of connections) {
+        if (conn.ws && conn.ws.readyState === WebSocket.OPEN) continue;
+
+        if (conn.lastConnected > 0 || conn.manual || authTokensByPort.has(port)) {
+            conn.attempts = 0;
+        }
+        connectToPort(port);
+    }
+}
+
 function ensurePortsForKnownTokens() {
     for (const port of authTokensByPort.keys()) {
         if (isAutoScanPort(port) || manualPorts.has(port)) {
@@ -159,6 +157,23 @@ function disconnectPort(port) {
         if (conn.ws) conn.ws.close();
         connections.delete(port);
     }
+}
+
+function visibleConnectionStatuses() {
+    const ports = [];
+    for (const [port, conn] of connections) {
+        // Only surface connections worth showing:
+        // - Currently connected or attempting an authenticated connection
+        // - Manually added by the user
+        // - Auto-scan ports with a known token or previous connection
+        const isVisible = conn.state === "connected"
+            || conn.state === "connecting"
+            || conn.manual
+            || (isAutoScanPort(port) && (authTokensByPort.has(port) || conn.lastConnected > 0));
+        if (!isVisible) continue;
+        ports.push({ port, state: conn.state, manual: conn.manual });
+    }
+    return ports;
 }
 
 // ─── Request Router ──────────────────────────────────────────────────
@@ -590,20 +605,13 @@ function delay(ms) {
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.type === "getStatus") {
-        const ports = [];
-        for (const [port, conn] of connections) {
-            // Only surface connections worth showing:
-            // - Currently connected
-            // - Manually added by the user
-            // - Auto-scan ports that have previously connected (server went away)
-            const isVisible = conn.state === "connected"
-                || conn.manual
-                || (isAutoScanPort(port) && conn.lastConnected > 0);
-            if (!isVisible) continue;
-            ports.push({ port, state: conn.state, manual: conn.manual });
-        }
-        sendResponse({ ports });
-        return false;
+        loadAuthTokens().finally(() => {
+            reconnectKnownPorts();
+            setTimeout(() => {
+                sendResponse({ ports: visibleConnectionStatuses() });
+            }, 250);
+        });
+        return true;
     }
     if (message.type === "addPort") {
         const port = parseInt(message.port, 10);
@@ -634,12 +642,7 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         } else {
             // Only reconnect ports that aren't already connected
             loadAuthTokens().finally(() => {
-                for (const [port, conn] of connections) {
-                    if (!conn.ws || conn.ws.readyState !== WebSocket.OPEN) {
-                        conn.attempts = 0;
-                        connectToPort(port);
-                    }
-                }
+                reconnectKnownPorts();
             });
         }
         sendResponse({ ok: true });
@@ -673,7 +676,7 @@ if (typeof browser.alarms !== "undefined") {
                 // keep their attempt count so they get cleaned up below.
                 for (const [port, conn] of connections) {
                     if (!conn.ws || conn.ws.readyState !== WebSocket.OPEN) {
-                        if (conn.lastConnected > 0 || conn.manual) {
+                        if (conn.lastConnected > 0 || conn.manual || authTokensByPort.has(port)) {
                             conn.attempts = 0;
                         }
                         connectToPort(port);

--- a/MCPSafari/MCPSafari Extension/Resources/popup.js
+++ b/MCPSafari/MCPSafari Extension/Resources/popup.js
@@ -61,6 +61,9 @@ async function refresh() {
 document.addEventListener("DOMContentLoaded", async () => {
     await refresh();
 
+    const refreshTimer = setInterval(refresh, 1000);
+    window.addEventListener("unload", () => clearInterval(refreshTimer));
+
     document.getElementById("add-btn").addEventListener("click", async () => {
         const input = document.getElementById("port-input");
         const port = parseInt(input.value, 10);

--- a/MCPSafari/MCPSafari Extension/SafariWebExtensionHandler.swift
+++ b/MCPSafari/MCPSafari Extension/SafariWebExtensionHandler.swift
@@ -6,6 +6,7 @@
 //
 
 import SafariServices
+import Darwin
 import os.log
 
 class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
@@ -35,30 +36,14 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         if let dict = message as? [String: Any],
            let type = dict["type"] as? String,
            type == "getToken" || type == "getTokens" {
-            let configDirectory = FileManager.default.homeDirectoryForCurrentUser
-                .appendingPathComponent(".config/mcp-safari")
-            let tokenDirectory = configDirectory.appendingPathComponent("tokens")
-            let legacyTokenPath = configDirectory.appendingPathComponent("token")
+            let result = Self.loadTokens()
 
-            var tokens: [String: String] = [:]
-            if let files = try? FileManager.default.contentsOfDirectory(
-                at: tokenDirectory,
-                includingPropertiesForKeys: nil
-            ) {
-                for file in files {
-                    guard UInt16(file.lastPathComponent) != nil,
-                          let token = try? String(contentsOf: file, encoding: .utf8)
-                    else { continue }
-                    tokens[file.lastPathComponent] = token.trimmingCharacters(in: .whitespacesAndNewlines)
-                }
-            }
-
-            if !tokens.isEmpty {
-                responseBody = ["tokens": tokens]
-            } else if let token = try? String(contentsOf: legacyTokenPath, encoding: .utf8) {
-                responseBody = ["token": token.trimmingCharacters(in: .whitespacesAndNewlines)]
+            if !result.tokens.isEmpty {
+                responseBody = ["tokens": result.tokens]
+            } else if let token = result.legacyToken {
+                responseBody = ["token": token]
             } else {
-                responseBody = ["error": "No token files found in \(tokenDirectory.path)"]
+                responseBody = ["error": "No token files found in \(result.checkedPaths.joined(separator: ", "))"]
             }
         } else {
             responseBody = ["echo": message as Any]
@@ -72,6 +57,96 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         }
 
         context.completeRequest(returningItems: [ response ], completionHandler: nil)
+    }
+
+    private struct TokenLoadResult {
+        let tokens: [String: String]
+        let legacyToken: String?
+        let checkedPaths: [String]
+    }
+
+    private static func loadTokens() -> TokenLoadResult {
+        var checkedPaths: [String] = []
+
+        for configDirectory in tokenConfigDirectories() {
+            let tokenDirectory = configDirectory.appendingPathComponent("tokens")
+            checkedPaths.append(tokenDirectory.path)
+
+            let tokens = readPortTokens(from: tokenDirectory)
+            if !tokens.isEmpty {
+                return TokenLoadResult(tokens: tokens, legacyToken: nil, checkedPaths: checkedPaths)
+            }
+
+            let legacyTokenPath = configDirectory.appendingPathComponent("token")
+            checkedPaths.append(legacyTokenPath.path)
+
+            if let token = readToken(at: legacyTokenPath) {
+                return TokenLoadResult(tokens: [:], legacyToken: token, checkedPaths: checkedPaths)
+            }
+        }
+
+        return TokenLoadResult(tokens: [:], legacyToken: nil, checkedPaths: checkedPaths)
+    }
+
+    private static func tokenConfigDirectories() -> [URL] {
+        var directories: [URL] = []
+
+        if let realHomeDirectory {
+            appendUnique(
+                realHomeDirectory.appendingPathComponent(".config/mcp-safari"),
+                to: &directories
+            )
+        }
+
+        appendUnique(
+            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".config/mcp-safari"),
+            to: &directories
+        )
+
+        return directories
+    }
+
+    private static var realHomeDirectory: URL? {
+        guard let passwordEntry = getpwuid(getuid()),
+              let homeDirectory = passwordEntry.pointee.pw_dir
+        else { return nil }
+
+        return URL(fileURLWithPath: String(cString: homeDirectory), isDirectory: true)
+    }
+
+    private static func appendUnique(_ url: URL, to directories: inout [URL]) {
+        let path = url.standardizedFileURL.path
+
+        if !directories.contains(where: { $0.standardizedFileURL.path == path }) {
+            directories.append(url)
+        }
+    }
+
+    private static func readPortTokens(from tokenDirectory: URL) -> [String: String] {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: tokenDirectory,
+            includingPropertiesForKeys: nil
+        ) else { return [:] }
+
+        var tokens: [String: String] = [:]
+        for file in files {
+            guard UInt16(file.lastPathComponent) != nil,
+                  let token = readToken(at: file)
+            else { continue }
+
+            tokens[file.lastPathComponent] = token
+        }
+
+        return tokens
+    }
+
+    private static func readToken(at file: URL) -> String? {
+        guard let token = try? String(contentsOf: file, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !token.isEmpty
+        else { return nil }
+
+        return token
     }
 
 }

--- a/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
+++ b/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
@@ -376,6 +376,7 @@
 		9DC62F122F717081006535B1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 27;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
@@ -411,6 +412,7 @@
 		9DC62F132F717081006535B1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 27;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;


### PR DESCRIPTION
## Summary
- Load MCP auth tokens from the real macOS home directory before falling back to the extension sandbox container.
- Wire a focused Safari extension entitlement for read-only access to `~/.config/mcp-safari/`.
- Require every WebSocket connection to authenticate before the extension reports it as connected.
- Reload tokens and reconnect known ports when the popup asks for status.
- Refresh the popup while open so auto-connect/auth handshakes do not leave stale "Scanning" or "connecting" UI.

## Why
v0.2.6 made WebSocket auth mandatory before the server promotes a socket to the active bridge. The Safari extension native handler currently reads tokens from `FileManager.default.homeDirectoryForCurrentUser`, which resolves to the sandbox container, not the real user home where the server writes `~/.config/mcp-safari/tokens/<port>`.

That means the popup can show raw WebSocket/manual-port state, while MCP tools still fail with `No Safari extension connected` because the server never receives a valid `{ "auth": token }` handshake.

## Verification
- `node --check 'MCPSafari/MCPSafari Extension/Resources/background.js'`
- `node --check 'MCPSafari/MCPSafari Extension/Resources/popup.js'`
- `git diff --check`
- `xcodebuild -project MCPSafari/MCPSafari.xcodeproj -scheme MCPSafari -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/MCPSafariAuthBuild build CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO`
- Confirmed built appex entitlements include `com.apple.security.temporary-exception.files.home-relative-path.read-only` with `/.config/mcp-safari/`.

Note: this repo marks `*.pbxproj` as binary; the project-file change is only adding `CODE_SIGN_ENTITLEMENTS` to the extension target Debug and Release build settings.
