### PR TITLE
ci: add security scanning workflows

### DIFF
--- a/.github/scripts/audit_swiftpm_osv.py
+++ b/.github/scripts/audit_swiftpm_osv.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+OSV_QUERY_BATCH_URL = "https://api.osv.dev/v1/querybatch"
+
+
+@dataclass(frozen=True)
+class Pin:
+    identity: str
+    location: str
+    version: str | None
+    revision: str | None
+    source: Path
+
+    @property
+    def repository_name(self) -> str:
+        return normalize_repository_name(self.location)
+
+
+@dataclass(frozen=True)
+class Query:
+    pin: Pin
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class Vulnerability:
+    id: str
+    pin: Pin
+
+
+def normalize_repository_name(location: str) -> str:
+    repository = location.strip()
+    if repository.startswith("git@github.com:"):
+        repository = "github.com/" + repository.removeprefix("git@github.com:")
+    for prefix in ("https://", "http://", "ssh://git@"):
+        if repository.startswith(prefix):
+            repository = repository.removeprefix(prefix)
+    repository = repository.rstrip("/")
+    if repository.endswith(".git"):
+        repository = repository[:-4]
+    return repository.lower()
+
+
+def load_pins(lockfiles: list[Path]) -> list[Pin]:
+    pins: list[Pin] = []
+    for lockfile in lockfiles:
+        with lockfile.open(encoding="utf-8") as package_resolved:
+            data = json.load(package_resolved)
+        for pin in data.get("pins", []):
+            state = pin.get("state", {})
+            pins.append(
+                Pin(
+                    identity=pin["identity"],
+                    location=pin["location"],
+                    version=state.get("version"),
+                    revision=state.get("revision"),
+                    source=lockfile,
+                )
+            )
+    return pins
+
+
+def build_queries(pins: list[Pin]) -> list[Query]:
+    queries: list[Query] = []
+    seen: set[str] = set()
+
+    def add(pin: Pin, payload: dict[str, Any]) -> None:
+        key = json.dumps(payload, sort_keys=True)
+        if key not in seen:
+            queries.append(Query(pin=pin, payload=payload))
+            seen.add(key)
+
+    for pin in pins:
+        if pin.version:
+            for name in (pin.identity, pin.repository_name):
+                add(
+                    pin,
+                    {
+                        "package": {"ecosystem": "SwiftURL", "name": name},
+                        "version": pin.version,
+                    },
+                )
+            add(pin, {"package": {"purl": f"pkg:swift/{pin.identity}@{pin.version}"}})
+        if pin.revision:
+            add(pin, {"commit": pin.revision})
+
+    return queries
+
+
+def query_osv(queries: list[Query]) -> list[dict[str, Any]]:
+    request = urllib.request.Request(
+        OSV_QUERY_BATCH_URL,
+        data=json.dumps({"queries": [query.payload for query in queries]}).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        data = json.load(response)
+
+    results = data.get("results", [])
+    if len(results) != len(queries):
+        raise RuntimeError(
+            f"OSV returned {len(results)} results for {len(queries)} queries"
+        )
+    return results
+
+
+def collect_vulnerabilities(
+    queries: list[Query], results: list[dict[str, Any]]
+) -> list[Vulnerability]:
+    vulnerabilities: list[Vulnerability] = []
+    seen: set[tuple[str, str, str | None]] = set()
+    for query, result in zip(queries, results, strict=True):
+        for vulnerability in result.get("vulns", []):
+            vulnerability_id = vulnerability["id"]
+            key = (query.pin.identity, vulnerability_id, query.pin.version)
+            if key in seen:
+                continue
+            vulnerabilities.append(Vulnerability(id=vulnerability_id, pin=query.pin))
+            seen.add(key)
+    return vulnerabilities
+
+
+def describe_pin(pin: Pin) -> str:
+    if pin.version:
+        return f"{pin.identity} {pin.version}"
+    return f"{pin.identity} {pin.revision}"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Audit SwiftPM Package.resolved dependencies with OSV.dev."
+    )
+    parser.add_argument("lockfiles", nargs="+", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        pins = load_pins(args.lockfiles)
+        queries = build_queries(pins)
+        if not queries:
+            print("No SwiftPM pins with versions or revisions found.")
+            return 0
+
+        results = query_osv(queries)
+    except (OSError, json.JSONDecodeError, urllib.error.URLError, RuntimeError) as error:
+        print(f"::error::SwiftPM OSV audit failed: {error}", file=sys.stderr)
+        return 2
+
+    vulnerabilities = collect_vulnerabilities(queries, results)
+    if vulnerabilities:
+        for vulnerability in vulnerabilities:
+            print(
+                f"::error file={vulnerability.pin.source}::"
+                f"{vulnerability.id} affects {describe_pin(vulnerability.pin)}",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"No OSV vulnerabilities found for {len(pins)} SwiftPM pins.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/test_audit_swiftpm_osv.py
+++ b/.github/scripts/test_audit_swiftpm_osv.py
@@ -1,0 +1,90 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import audit_swiftpm_osv as audit
+
+
+class AuditSwiftPMOSVTests(unittest.TestCase):
+    def test_load_pins_reads_swift_package_resolved(self):
+        package_resolved = {
+            "pins": [
+                {
+                    "identity": "swift-nio",
+                    "location": "https://github.com/apple/swift-nio.git",
+                    "state": {
+                        "revision": "abc123",
+                        "version": "2.97.0",
+                    },
+                }
+            ]
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            lockfile = Path(temp_dir) / "Package.resolved"
+            lockfile.write_text(json.dumps(package_resolved), encoding="utf-8")
+
+            pins = audit.load_pins([lockfile])
+
+        self.assertEqual(len(pins), 1)
+        self.assertEqual(pins[0].identity, "swift-nio")
+        self.assertEqual(pins[0].version, "2.97.0")
+        self.assertEqual(pins[0].repository_name, "github.com/apple/swift-nio")
+
+    def test_build_queries_checks_identity_repository_and_commit(self):
+        pin = audit.Pin(
+            identity="swift-nio",
+            location="https://github.com/apple/swift-nio.git",
+            version="2.97.0",
+            revision="abc123",
+            source=Path("MCPServer/Package.resolved"),
+        )
+
+        queries = audit.build_queries([pin])
+        payloads = [query.payload for query in queries]
+
+        self.assertIn(
+            {
+                "package": {"ecosystem": "SwiftURL", "name": "swift-nio"},
+                "version": "2.97.0",
+            },
+            payloads,
+        )
+        self.assertIn(
+            {
+                "package": {
+                    "ecosystem": "SwiftURL",
+                    "name": "github.com/apple/swift-nio",
+                },
+                "version": "2.97.0",
+            },
+            payloads,
+        )
+        self.assertIn({"commit": "abc123"}, payloads)
+
+    def test_collect_vulnerabilities_deduplicates_results(self):
+        pin = audit.Pin(
+            identity="swift-crypto",
+            location="https://github.com/apple/swift-crypto.git",
+            version="4.0.0",
+            revision="abc123",
+            source=Path("Package.resolved"),
+        )
+        queries = [
+            audit.Query(pin=pin, payload={"package": {"name": "swift-crypto"}}),
+            audit.Query(pin=pin, payload={"commit": "abc123"}),
+        ]
+        results = [
+            {"vulns": [{"id": "GHSA-9m44-rr2w-ppp7"}]},
+            {"vulns": [{"id": "GHSA-9m44-rr2w-ppp7"}]},
+        ]
+
+        vulnerabilities = audit.collect_vulnerabilities(queries, results)
+
+        self.assertEqual(len(vulnerabilities), 1)
+        self.assertEqual(vulnerabilities[0].id, "GHSA-9m44-rr2w-ppp7")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -16,10 +16,28 @@ permissions:
 jobs:
   analyze:
     name: Analyze (Swift)
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Select Xcode 26.4
+        run: |
+          set -euo pipefail
+
+          for app in /Applications/Xcode_26.4.app /Applications/Xcode_26.4.0.app /Applications/Xcode.app; do
+            if [ -d "$app/Contents/Developer" ]; then
+              sudo xcode-select -s "$app/Contents/Developer"
+              break
+            fi
+          done
+
+          xcodebuild -version
+          swift --version
+          swift --version | grep -q "Apple Swift version 6.3" || {
+            echo "::error::Swift 6.3 is required to build MCPServer"
+            exit 1
+          }
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -1,0 +1,35 @@
+name: Security - CodeQL
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  schedule:
+    - cron: '23 4 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (Swift)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+
+      - name: Build
+        run: |
+          cd MCPServer
+          swift build -c release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -22,9 +22,22 @@ jobs:
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          install_dir="${RUNNER_TEMP}/gitleaks"
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          base_url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+
+          mkdir -p "${install_dir}"
+          cd "${install_dir}"
+          curl --fail --location --show-error --silent "${base_url}/${archive}" --output "${archive}"
+          curl --fail --location --show-error --silent "${base_url}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" --output gitleaks_checksums.txt
+          sha256sum --check --ignore-missing gitleaks_checksums.txt
+
+          tar -xzf "${archive}" gitleaks
+          sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
+          gitleaks detect --source "${GITHUB_WORKSPACE}" --redact --verbose
 
   osv:
     name: Dependency vulnerabilities (OSV)

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -1,0 +1,41 @@
+name: Security - Secrets & Dependency Audit
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  schedule:
+    - cron: '41 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  osv:
+    name: Dependency vulnerabilities (OSV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run OSV-Scanner
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
+        with:
+          scan-args: |-
+            --recursive
+            --lockfile=MCPServer/Package.resolved

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -33,9 +33,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run OSV-Scanner
-        uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
-        with:
-          scan-args: |-
-            --recursive
-            --lockfile=MCPServer/Package.resolved
+      - name: Test SwiftPM OSV audit
+        run: python3 .github/scripts/test_audit_swiftpm_osv.py
+
+      - name: Run SwiftPM OSV audit
+        run: python3 .github/scripts/audit_swiftpm_osv.py MCPServer/Package.resolved

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Security support is provided for the latest released version on `main`.
+
+## Reporting a Vulnerability
+
+Please do **not** open public issues for suspected vulnerabilities.
+
+Instead, email the maintainer privately with:
+- A clear description of the issue
+- Reproduction steps / proof of concept
+- Potential impact
+- Suggested remediation (if known)
+
+We will acknowledge receipt as soon as possible and work on a fix before public disclosure.
+
+## Security Controls in this Repository
+
+This repository includes automated security scanning via GitHub Actions:
+- **CodeQL** for static analysis of Swift code
+- **Gitleaks** for accidental secret detection
+- **OSV-Scanner** for vulnerable dependency detection
+
+These checks run on pull requests, pushes to the default branch, and on a weekly schedule.


### PR DESCRIPTION
## Summary

- Add CodeQL security scanning for Swift sources.
- Add a secrets scan with Gitleaks.
- Add an OSV.dev dependency audit for SwiftPM pins in `Package.resolved`.
- Pin the CodeQL job to the Swift 6.3 runner image so the MCP server build can be analyzed.

## Validation

- Fork test PR: https://github.com/balcsida/MCPSafari/pull/2
- CI: https://github.com/balcsida/MCPSafari/actions/runs/26227355548
- Security - Secrets & Dependency Audit: https://github.com/balcsida/MCPSafari/actions/runs/26227355150
- Security - CodeQL: https://github.com/balcsida/MCPSafari/actions/runs/26227355149
