### PR TITLE
ci: use non-deprecated gitleaks git command

### DIFF
--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -37,7 +37,7 @@ jobs:
 
           tar -xzf "${archive}" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
-          gitleaks detect --source "${GITHUB_WORKSPACE}" --redact --verbose
+          gitleaks git "${GITHUB_WORKSPACE}" --redact --verbose
 
   osv:
     name: Dependency vulnerabilities (OSV)


### PR DESCRIPTION
Follow-up nit from #17.

`gitleaks` 8.x deprecated `detect --source <path>` in favor of the `git <path>` subcommand. This updates the secret-scan step to the current syntax so it stops emitting the deprecation warning. Same scan behavior (full history, redacted, verbose).