### PR TITLE
Release v0.2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode 26.4
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode 26.4
         run: |
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/security-codeql.yml
+++ b/.github/workflows/security-codeql.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode 26.4
         run: |

--- a/.github/workflows/security-secrets.yml
+++ b/.github/workflows/security-secrets.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -37,14 +37,14 @@ jobs:
 
           tar -xzf "${archive}" gitleaks
           sudo install -m 0755 gitleaks /usr/local/bin/gitleaks
-          gitleaks detect --source "${GITHUB_WORKSPACE}" --redact --verbose
+          gitleaks git "${GITHUB_WORKSPACE}" --redact --verbose
 
   osv:
     name: Dependency vulnerabilities (OSV)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test SwiftPM OSV audit
         run: python3 .github/scripts/test_audit_swiftpm_osv.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.2.9] - 2026-06-06
+### Added
+- `select_tab` now exposes its `bringToFront` option (activate and focus the tab, default `true`) in the tool schema and description.
+
+### Documentation
+- Documented that `press_key` modifier combos and `drag` dispatch synthetic events and do not trigger native browser actions (clipboard, select-all) or HTML5 drag-and-drop.
+- Noted that `read_console`/`read_network` telemetry is captured in the page main world and should be treated as page-controlled data on untrusted pages.
+
+### CI
+- Ran the gitleaks secret scan via the non-deprecated `gitleaks git` command.
+- Bumped `actions/checkout` to v5 across all workflows to clear the Node 20 runner deprecation.
+
+### Build
+- Bumped app, extension, and server versions to `0.2.9`.
+
 ## [0.2.8] - 2026-05-07
 ### Bug Fixes
 - Fixed a host app launch crash when SafariServices returned extension state on a non-main XPC callback queue.

--- a/MCPSafari/MCPSafari Extension/Resources/manifest.json
+++ b/MCPSafari/MCPSafari Extension/Resources/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "__MSG_extension_name__",
     "description": "__MSG_extension_description__",
-    "version": "0.2.8",
+    "version": "0.2.9",
 
     "icons": {
         "48": "images/icon-48.png",

--- a/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
+++ b/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -393,7 +393,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -414,7 +414,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -429,7 +429,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -572,7 +572,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -587,7 +587,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -613,7 +613,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -628,7 +628,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -652,11 +652,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -673,11 +673,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -693,10 +693,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -712,10 +712,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 28;
+				CURRENT_PROJECT_VERSION = 29;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.2.8;
+				MARKETING_VERSION = 0.2.9;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -14,7 +14,7 @@ actor SafariMCPServer {
         self.bridge = try WebSocketBridge(port: port, logger: logger)
         self.server = Server(
             name: "mcp-safari",
-            version: "0.2.8",
+            version: "0.2.9",
             instructions: """
                 Safari browser automation. Use tabs_context to list tabs, snapshot for element UIDs, \
                 then click/type_text/hover by UID. Use includeSnapshot on interactions to see updated state.
@@ -128,10 +128,13 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "select_tab",
-                description: "Pin a tab as default context for future calls.",
+                description: "Pin a tab as default context for future calls. Activates and focuses the tab unless bringToFront is false.",
                 inputSchema: .object([
                     "type": .string("object"),
-                    "properties": .object(["tabId": Self.tab]),
+                    "properties": .object([
+                        "tabId": Self.tab,
+                        "bringToFront": .object(["type": .string("boolean"), "description": .string("Activate and focus the tab (default: true)")]),
+                    ]),
                     "required": .array([.string("tabId")]),
                 ])
             ),

--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ For ports outside the default range, add them manually in the extension popup or
 | `hover` | Hover to trigger tooltips, menus, or hover states |
 | `drag` | Drag and drop between elements |
 
+> **Note:** Interaction tools drive elements via synthetic DOM events (and React-compatible value setting for text), which works across the vast majority of sites. Because the events are synthetic, `press_key` modifier combos (e.g. `Meta+a`, `Control+c`) and `drag` reach page-level JS handlers but do **not** trigger native browser actions — clipboard copy/paste, select-all, or HTML5 native drag-and-drop. Use `type_text`/`form_input` for text entry and `javascript_tool` when a true native action is required.
+
 ### Dialogs
 
 | Tool | Description |
@@ -272,6 +274,8 @@ For ports outside the default range, add them manually in the extension popup or
 |------|-------------|
 | `read_console` | Read console messages with level and regex filtering |
 | `read_network` | Read captured XHR/fetch requests with type filtering |
+
+> **Note:** Console and network capture run in the page's main world (required to patch `console`, `fetch`, and `history`). A hostile page can therefore observe or forge this telemetry, so treat `read_console` / `read_network` output from untrusted pages as page-controlled data rather than ground truth.
 
 ### Window
 


### PR DESCRIPTION
Release **v0.2.9** — folds in the diligence findings, the gitleaks fix from #19, and version bumps.

## Changes
- **`select_tab`**: expose the `bringToFront` option in the tool schema + description (handler already supported it; it was undocumented).
- **Docs**: note that `press_key` modifier combos and `drag` dispatch synthetic events and do not trigger native browser actions (clipboard, select-all) or HTML5 drag-and-drop; note that `read_console`/`read_network` telemetry is page-controlled on untrusted pages.
- **CI**: run gitleaks via the non-deprecated `gitleaks git` command (supersedes #19); bump `actions/checkout` to v5 across all workflows to clear the Node 20 runner deprecation.
- **Version**: bump app, extension, and server to `0.2.9` (+ CHANGELOG).

## Verification (local)
- `swift build -c release` ✅ and `swift test` ✅ (2/2)
- MCP handshake reports `{"name":"mcp-safari","version":"0.2.9"}` ✅
- `plutil -lint` on the pbxproj ✅, manifest.json valid ✅

## Release process
On merge, tagging `v0.2.9` triggers the release workflow (build/sign/notarize → universal binary → GitHub Release). The Homebrew tap will then be bumped to 0.2.9 with the published checksums.

Supersedes #19.