### PR TITLE
fix: prevent snapshot crashes on SVG elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Bug Fixes
+- Fixed `snapshot` crashing on SVG elements with non-string `type` properties.
 
 ## [0.2.9] - 2026-06-06
 ### Added

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -218,10 +218,11 @@
 
         // Implicit roles by tag
         const tag = element.tagName ? element.tagName.toLowerCase() : "";
+        if (tag === "input") return getInputRole(element);
+
         const implicitRoles = {
             a: "link",
             button: "button",
-            input: getInputRole(element),
             select: "combobox",
             textarea: "textbox",
             img: "img",


### PR DESCRIPTION
Fixes #21.

`getRole()` built every implicit role eagerly, so `getInputRole()` ran for all elements. SVG elements such as `<feColorMatrix>` expose `type` as an `SVGAnimatedEnumeration`, causing `.toLowerCase()` to throw.

This change only evaluates input roles for actual `<input>` elements.

Tested:

- reproduced on v0.2.9 with a sanitized SVG fixture
- patched extension returns the full snapshot
- checkbox role detection remains unchanged
- Swift tests and signed app build pass
