### PR TITLE
feat: add optional native keyboard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added a bridge-independent `status` MCP tool for listener, authentication, version, and token health.
 - Added a backward-compatible versioned extension/server handshake with explicit protocol mismatch errors.
 - Tool failures now include stable error codes, retry guidance, and recovery actions for disconnected bridges, stale element UIDs, missing targets, and wait timeouts.
+- `type_text` now supports opt-in native macOS keyboard events for contenteditable and framework-managed editors.
 
 ### Bug Fixes
 - Stop stale per-port token files from causing endless extension reconnect attempts and popup state cycling.

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -255,6 +255,10 @@ async function handleRequest(request) {
                 data = await handleNavigate(params);
                 break;
 
+            case "native_type_text":
+                data = await handleNativeTypeText(params);
+                break;
+
             // Page reading (delegated to content script)
             case "read_page":
             case "get_page_text":
@@ -397,6 +401,19 @@ async function handleSelectTab(params) {
         title: tab.title || "",
         selected: true,
     };
+}
+
+async function handleNativeTypeText(params) {
+    const tabId = params.tabId || (await getActiveTabId());
+    const tab = await browser.tabs.get(tabId);
+    await browser.tabs.update(tabId, { active: true });
+    await browser.windows.update(tab.windowId, { focused: true });
+    await delay(100);
+    await sendToContentScript(tabId, {
+        action: "prepare_native_input",
+        params,
+    });
+    return "Safari is ready for native input";
 }
 
 function persistSelectedTab(tabId) {

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -103,6 +103,8 @@
                 return clickElement(params);
             case "type_text":
                 return typeText(params);
+            case "prepare_native_input":
+                return prepareNativeInput(params);
             case "form_input":
                 return formInput(params);
             case "select_option":
@@ -560,6 +562,47 @@
     }
 
     // ─── Type Text ───────────────────────────────────────────────────
+
+    function prepareNativeInput(params) {
+        const el = (params.uid || params.selector)
+            ? resolveElement(params)
+            : document.activeElement;
+        if (!el) {
+            throw toolError(
+                "target_not_found",
+                "No element to type into",
+                false,
+                "take_snapshot"
+            );
+        }
+
+        const tag = el.tagName.toLowerCase();
+        const textInputTypes = new Set([
+            "text", "search", "url", "tel", "email", "password", "number",
+        ]);
+        const isTextInput = tag === "textarea"
+            || (tag === "input" && textInputTypes.has(el.type));
+        if ((!isTextInput && !el.isContentEditable) || el.disabled || el.readOnly) {
+            throw toolError(
+                "unsupported_native_target",
+                `Native typing requires an editable text control; received <${tag}>`,
+                false,
+                "use_synthetic_input"
+            );
+        }
+
+        el.scrollIntoView({ block: "center", inline: "center" });
+        el.focus({ preventScroll: true });
+        if (document.activeElement !== el && !el.contains(document.activeElement)) {
+            throw toolError(
+                "native_input_focus_failed",
+                `Could not focus <${tag}> for native typing`,
+                true,
+                "retry"
+            );
+        }
+        return `Focused <${tag}> for native typing`;
+    }
 
     function typeText(params) {
         const el = (params.uid || params.selector)

--- a/MCPSafari/MCPSafari/Base.lproj/Main.storyboard
+++ b/MCPSafari/MCPSafari/Base.lproj/Main.storyboard
@@ -80,7 +80,7 @@
                     <window key="window" title="MCPSafari" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
                         <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
-                        <rect key="contentRect" x="196" y="240" width="425" height="325"/>
+                        <rect key="contentRect" x="196" y="240" width="460" height="320"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
                         <connections>
                             <outlet property="delegate" destination="B8D-0N-5wS" id="98r-iN-zZc"/>
@@ -99,11 +99,11 @@
             <objects>
                 <viewController id="XfG-lQ-9wD" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="425" height="325"/>
+                        <rect key="frame" x="0.0" y="0.0" width="460" height="320"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <wkWebView wantsLayer="YES" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOr-cG-IQY">
-                                <rect key="frame" x="0.0" y="0.0" width="425" height="325"/>
+                                <rect key="frame" x="0.0" y="0.0" width="460" height="320"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <wkWebViewConfiguration key="configuration">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>

--- a/MCPSafari/MCPSafari/Resources/Base.lproj/Main.html
+++ b/MCPSafari/MCPSafari/Resources/Base.lproj/Main.html
@@ -10,10 +10,31 @@
     <script src="../Script.js" defer></script>
 </head>
 <body>
-    <img src="../Icon.png" width="128" height="128" alt="MCPSafari Icon">
-    <p class="state-unknown">You can turn on MCPSafari’s extension in Safari Extensions preferences.</p>
-    <p class="state-on">MCPSafari’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
-    <p class="state-off">MCPSafari’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
-    <button class="open-preferences">Quit and Open Safari Extensions Preferences…</button>
+    <main>
+        <header>
+            <img src="../Icon.png" width="48" height="48" alt="MCPSafari icon">
+            <h1>MCPSafari</h1>
+        </header>
+
+        <section class="setting">
+            <h2>Safari extension</h2>
+            <div class="setting-actions">
+                <span class="status state-unknown">Checking</span>
+                <span class="status state-on">Enabled</span>
+                <span class="status state-off">Not enabled</span>
+                <button class="open-preferences">Safari Settings…</button>
+            </div>
+        </section>
+
+        <section class="setting">
+            <div class="setting-copy">
+                <h2>Native keyboard input</h2>
+                <p>Optional. Grant Accessibility to Codex, Claude, or the terminal running your MCP server.</p>
+            </div>
+            <div class="setting-actions">
+                <button class="enable-native-input">Accessibility Settings…</button>
+            </div>
+        </section>
+    </main>
 </body>
 </html>

--- a/MCPSafari/MCPSafari/Resources/Script.js
+++ b/MCPSafari/MCPSafari/Resources/Script.js
@@ -1,11 +1,4 @@
-function show(enabled, useSettingsInsteadOfPreferences) {
-    if (useSettingsInsteadOfPreferences) {
-        document.getElementsByClassName('state-on')[0].innerText = "MCPSafari’s extension is currently on. You can turn it off in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('state-off')[0].innerText = "MCPSafari’s extension is currently off. You can turn it on in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('state-unknown')[0].innerText = "You can turn on MCPSafari’s extension in the Extensions section of Safari Settings.";
-        document.getElementsByClassName('open-preferences')[0].innerText = "Quit and Open Safari Settings…";
-    }
-
+function show(enabled) {
     if (typeof enabled === "boolean") {
         document.body.classList.toggle(`state-on`, enabled);
         document.body.classList.toggle(`state-off`, !enabled);
@@ -19,4 +12,9 @@ function openPreferences() {
     webkit.messageHandlers.controller.postMessage("open-preferences");
 }
 
+function enableNativeInput() {
+    webkit.messageHandlers.controller.postMessage("enable-native-input");
+}
+
 document.querySelector("button.open-preferences").addEventListener("click", openPreferences);
+document.querySelector("button.enable-native-input").addEventListener("click", enableNativeInput);

--- a/MCPSafari/MCPSafari/Resources/Style.css
+++ b/MCPSafari/MCPSafari/Resources/Style.css
@@ -6,8 +6,17 @@
 
 :root {
     color-scheme: light dark;
+    --border: rgba(127, 127, 127, 0.28);
+    --muted: #555;
+    --positive: #137333;
+    --surface: rgba(127, 127, 127, 0.12);
+}
 
-    --spacing: 20px;
+@media (prefers-color-scheme: dark) {
+    :root {
+        --muted: #b8b8b8;
+        --positive: #62d482;
+    }
 }
 
 html {
@@ -15,17 +24,85 @@ html {
 }
 
 body {
+    margin: 0;
+    height: 100%;
+    overflow: hidden;
+    background: Canvas;
+    color: CanvasText;
+    font: -apple-system-body;
+}
+
+main {
+    box-sizing: border-box;
+    width: min(100%, 460px);
+    margin: 0 auto;
+    padding: 24px;
+}
+
+header {
     display: flex;
     align-items: center;
-    justify-content: center;
-    flex-direction: column;
+    gap: 12px;
+    padding-bottom: 18px;
+}
 
-    gap: var(--spacing);
-    margin: 0 calc(var(--spacing) * 2);
-    height: 100%;
+header img {
+    flex: none;
+}
 
-    font: -apple-system-short-body;
+h1,
+h2,
+p {
+    margin: 0;
+}
+
+h1 {
+    font: -apple-system-title1;
+    font-weight: 650;
+}
+
+h2 {
+    font: -apple-system-headline;
+}
+
+.setting {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 16px;
+    min-height: 58px;
+    padding: 16px 0;
+    border-top: 1px solid var(--border);
+}
+
+.setting-copy p {
+    max-width: 260px;
+    margin-top: 4px;
+    color: var(--muted);
+    line-height: 1.35;
+}
+
+.setting-actions {
+    display: grid;
+    justify-items: end;
+    gap: 8px;
+}
+
+.status {
+    flex: none;
+    box-sizing: border-box;
+    min-width: 82px;
+    padding: 4px 9px;
+    border-radius: 6px;
+    background: var(--surface);
+    font: -apple-system-caption1;
+    font-weight: 600;
     text-align: center;
+}
+
+.state-on.status {
+    background: color-mix(in srgb, var(--positive) 18%, transparent);
+    color: var(--positive);
 }
 
 body:not(.state-on, .state-off) :is(.state-on, .state-off) {
@@ -41,5 +118,9 @@ body.state-off :is(.state-on, .state-unknown) {
 }
 
 button {
-    font-size: 1em;
+    margin: 0;
+    min-height: 28px;
+    padding: 3px 12px;
+    font: -apple-system-body;
+    cursor: default;
 }

--- a/MCPSafari/MCPSafari/ViewController.swift
+++ b/MCPSafari/MCPSafari/ViewController.swift
@@ -10,6 +10,7 @@ import SafariServices
 import WebKit
 
 nonisolated let extensionBundleIdentifier = "com.epistates.MCPSafari.Extension"
+nonisolated private let accessibilitySettingsURL = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
 
 class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
 
@@ -51,14 +52,15 @@ class ViewController: NSViewController, WKNavigationDelegate, WKScriptMessageHan
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        if (message.body as! String != "open-preferences") {
-            return;
-        }
+        guard let action = message.body as? String else { return }
 
-        SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { error in
-            DispatchQueue.main.async {
-                NSApplication.shared.terminate(nil)
-            }
+        switch action {
+        case "open-preferences":
+            SFSafariApplication.showPreferencesForExtension(withIdentifier: extensionBundleIdentifier) { _ in }
+        case "enable-native-input":
+            NSWorkspace.shared.open(accessibilitySettingsURL)
+        default:
+            break
         }
     }
 

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -1,3 +1,6 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
 import Foundation
 import Logging
 import MCP
@@ -227,13 +230,17 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "type_text",
-                description: "Type into element. Supports clearFirst and submitKey (e.g. Enter).",
+                description: "Type into element. Set native=true for real macOS key events in editors that depend on keyboard input.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
                         "text": .object(["type": .string("string")]),
                         "uid": Self.uid, "selector": Self.sel,
                         "clearFirst": .object(["type": .string("boolean")]),
+                        "native": .object([
+                            "type": .string("boolean"),
+                            "description": .string("Use real macOS key events; foregrounds Safari and requires Accessibility permission"),
+                        ]),
                         "submitKey": .object(["type": .string("string"), "description": .string("Key after typing (Enter, Tab)")]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
                     ])),
@@ -433,7 +440,7 @@ actor SafariMCPServer {
             case "snapshot":        return try await handleSnapshot(args)
             case "find":            return try await handleFind(args)
             case "click":           return try await handleInteraction("click", args)
-            case "type_text":       return try await handleInteraction("type_text", args)
+            case "type_text":       return try await handleTypeText(args)
             case "form_input":      return try await handleFormInput(args)
             case "select_option":   return try await handleInteraction("select_option", args)
             case "scroll":          return try await handleInteraction("scroll", args)
@@ -579,18 +586,8 @@ actor SafariMCPServer {
     /// Unified handler for interaction tools: click, type_text, hover, scroll, press_key, select_option, drag.
     /// Forwards all params to the extension and optionally appends a snapshot.
     private func handleInteraction(_ action: String, _ args: [String: Value]) async throws -> CallTool.Result {
-        var params: [String: AnyCodable] = [:]
+        let params = interactionParams(args)
         let wantSnapshot = args["includeSnapshot"]?.boolValue == true
-
-        // Forward all value args (except includeSnapshot which is handled here)
-        for (key, value) in args {
-            if key == "includeSnapshot" || key == "tabId" || Self.actionControlKeys.contains(key) { continue }
-            if let s = value.stringValue { params[key] = AnyCodable(s) }
-            else if let i = value.intValue { params[key] = AnyCodable(i) }
-            else if let d = value.doubleValue { params[key] = AnyCodable(d) }
-            else if let b = value.boolValue { params[key] = AnyCodable(b) }
-        }
-        if let tabId = args["tabId"]?.intValue { params["tabId"] = AnyCodable(tabId) }
 
         let traceSession = try await startTraceIfNeeded(args)
         do {
@@ -602,6 +599,183 @@ actor SafariMCPServer {
             }
             throw error
         }
+    }
+
+    private func interactionParams(_ args: [String: Value]) -> [String: AnyCodable] {
+        var params: [String: AnyCodable] = [:]
+        for (key, value) in args {
+            if key == "includeSnapshot" || key == "tabId" || Self.actionControlKeys.contains(key) { continue }
+            if let s = value.stringValue { params[key] = AnyCodable(s) }
+            else if let i = value.intValue { params[key] = AnyCodable(i) }
+            else if let d = value.doubleValue { params[key] = AnyCodable(d) }
+            else if let b = value.boolValue { params[key] = AnyCodable(b) }
+        }
+        if let tabId = args["tabId"]?.intValue { params["tabId"] = AnyCodable(tabId) }
+        return params
+    }
+
+    private func handleTypeText(_ args: [String: Value]) async throws -> CallTool.Result {
+        if let native = args["native"], native.boolValue == nil {
+            throw ToolInputError("native must be a boolean")
+        }
+        guard args["native"]?.boolValue == true else {
+            return try await handleInteraction("type_text", args)
+        }
+        return try await handleNativeTypeText(args)
+    }
+
+    private func handleNativeTypeText(_ args: [String: Value]) async throws -> CallTool.Result {
+        let input = try Self.nativeInputPlan(args)
+        let traceSession = try await startTraceIfNeeded(args)
+        do {
+            let preparation = try await bridge.send(action: "native_type_text", params: interactionParams(args))
+            guard preparation.success else {
+                return try await resultAfterAction(preparation, args, traceSession: traceSession)
+            }
+
+            let message = try Self.typeNativeText(input)
+            let response = BridgeResponse(
+                id: preparation.id,
+                success: true,
+                data: AnyCodable(message),
+                error: nil,
+                errorCode: nil,
+                retryable: nil,
+                recoveryAction: nil
+            )
+            return try await resultAfterAction(response, args, traceSession: traceSession)
+        } catch {
+            if let traceSession {
+                _ = try? await stopTraceResponse(traceSession, args, waitForDuration: false)
+            }
+            throw error
+        }
+    }
+
+    private struct NativeInputError: Error {
+        let failure: ToolFailure
+    }
+
+    private struct NativeInputPlan {
+        let text: String
+        let clearFirst: Bool
+        let submitKey: String?
+        let submitKeyCode: CGKeyCode?
+    }
+
+    private nonisolated static func nativeInputPlan(_ args: [String: Value]) throws -> NativeInputPlan {
+        guard let text = args["text"]?.stringValue else {
+            throw ToolInputError("text is required")
+        }
+        if let clearFirst = args["clearFirst"], clearFirst.boolValue == nil {
+            throw ToolInputError("clearFirst must be a boolean")
+        }
+        if let submitKey = args["submitKey"], submitKey.stringValue == nil {
+            throw ToolInputError("submitKey must be a string")
+        }
+
+        let submitKey = args["submitKey"]?.stringValue
+        let submitKeyCode = try nativeSubmitKeyCode(for: submitKey)
+        guard AXIsProcessTrusted() else {
+            throw NativeInputError(failure: ToolFailure(
+                code: "native_input_permission_required",
+                message: "Native typing requires Accessibility permission for the app running mcp-safari (Codex, Claude, or your terminal). Enable that app in System Settings > Privacy & Security > Accessibility. Standard typing works without this permission.",
+                retryable: false,
+                recoveryAction: "grant_accessibility_to_mcp_client"
+            ))
+        }
+
+        return NativeInputPlan(
+            text: text,
+            clearFirst: args["clearFirst"]?.boolValue == true,
+            submitKey: submitKey,
+            submitKeyCode: submitKeyCode
+        )
+    }
+
+    private nonisolated static func typeNativeText(_ input: NativeInputPlan) throws -> String {
+        try ensureSafariIsFrontmost()
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            throw nativeInputUnavailable("macOS could not create a native keyboard event.")
+        }
+
+        if input.clearFirst {
+            try postKey(code: 0, flags: .maskCommand, source: source)
+            try postKey(code: 51, source: source)
+        }
+        for character in input.text {
+            try ensureSafariIsFrontmost()
+            try postText(String(character), source: source)
+        }
+        if let submitKeyCode = input.submitKeyCode {
+            try postKey(code: submitKeyCode, source: source)
+        }
+
+        let suffix = input.submitKey.map { " then pressed \($0)" } ?? ""
+        return "Typed \(input.text.count) character(s) with native input\(suffix)"
+    }
+
+    private nonisolated static func nativeSubmitKeyCode(for key: String?) throws -> CGKeyCode? {
+        guard let key else { return nil }
+        switch key.lowercased() {
+        case "enter", "return": return 36
+        case "tab": return 48
+        default: throw ToolInputError("Native submitKey does not support \(key). Use Enter, Return, or Tab.")
+        }
+    }
+
+    private nonisolated static func ensureSafariIsFrontmost() throws {
+        guard NSWorkspace.shared.frontmostApplication?.bundleIdentifier == "com.apple.Safari" else {
+            throw NativeInputError(failure: ToolFailure(
+                code: "native_input_focus_lost",
+                message: "Safari lost focus before native typing completed. Input may be partial; focus the target and retry.",
+                retryable: true,
+                recoveryAction: "retry"
+            ))
+        }
+    }
+
+    private nonisolated static func nativeInputUnavailable(_ message: String) -> NativeInputError {
+        NativeInputError(failure: ToolFailure(
+            code: "native_input_unavailable",
+            message: message,
+            retryable: false,
+            recoveryAction: "inspect_error"
+        ))
+    }
+
+    private nonisolated static func postText(_ text: String, source: CGEventSource) throws {
+        let utf16 = Array(text.utf16)
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: 0, keyDown: false)
+        else {
+            throw nativeInputUnavailable("macOS could not create a native keyboard event.")
+        }
+        utf16.withUnsafeBufferPointer { buffer in
+            keyDown.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: buffer.baseAddress)
+            keyUp.keyboardSetUnicodeString(stringLength: buffer.count, unicodeString: buffer.baseAddress)
+        }
+        keyDown.post(tap: .cgSessionEventTap)
+        keyUp.post(tap: .cgSessionEventTap)
+        Thread.sleep(forTimeInterval: 0.005)
+    }
+
+    private nonisolated static func postKey(
+        code: CGKeyCode,
+        flags: CGEventFlags = [],
+        source: CGEventSource
+    ) throws {
+        try ensureSafariIsFrontmost()
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: true),
+              let keyUp = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: false)
+        else {
+            throw nativeInputUnavailable("macOS could not create a native keyboard event.")
+        }
+        keyDown.flags = flags
+        keyUp.flags = flags
+        keyDown.post(tap: .cgSessionEventTap)
+        keyUp.post(tap: .cgSessionEventTap)
+        Thread.sleep(forTimeInterval: 0.005)
     }
 
     private func handleFormInput(_ args: [String: Value]) async throws -> CallTool.Result {
@@ -909,6 +1083,9 @@ actor SafariMCPServer {
     private func toolFailure(for error: any Error) -> ToolFailure {
         if let bridgeError = error as? WebSocketBridge.BridgeError {
             return bridgeError.toolFailure
+        }
+        if let nativeInputError = error as? NativeInputError {
+            return nativeInputError.failure
         }
         if let inputError = error as? ToolInputError {
             return ToolFailure(

--- a/Tests/AppPermissionUITests.mjs
+++ b/Tests/AppPermissionUITests.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const scriptSource = readFileSync(
+  new URL("../MCPSafari/MCPSafari/Resources/Script.js", import.meta.url),
+  "utf8",
+);
+
+function appHarness() {
+  const classes = new Set();
+  const messages = [];
+  const listeners = new Map();
+  const context = vm.createContext({
+    document: {
+      body: {
+        classList: {
+          remove: (...names) => names.forEach((name) => classes.delete(name)),
+          toggle: (name, enabled) => enabled ? classes.add(name) : classes.delete(name),
+        },
+      },
+      getElementsByClassName: () => [{ innerText: "" }],
+      querySelector: (selector) => ({
+        addEventListener: (event, listener) => listeners.set(`${selector}:${event}`, listener),
+      }),
+    },
+    webkit: {
+      messageHandlers: {
+        controller: {
+          postMessage: (message) => messages.push(message),
+        },
+      },
+    },
+  });
+
+  vm.runInContext(scriptSource, context);
+  return { classes, context, listeners, messages };
+}
+
+test("Accessibility button opens settings guidance", () => {
+  const { listeners, messages } = appHarness();
+
+  listeners.get("button.enable-native-input:click")();
+
+  assert.deepEqual(messages, ["enable-native-input"]);
+});

--- a/Tests/ExtensionToolErrorTests.mjs
+++ b/Tests/ExtensionToolErrorTests.mjs
@@ -12,7 +12,13 @@ const backgroundSource = readFileSync(
     "utf8"
 );
 
-function contentHarness() {
+function contentHarness(document = {
+    activeElement: null,
+    body: { innerText: "" },
+    createTreeWalker: () => ({ nextNode: () => null }),
+    elementFromPoint: () => null,
+    querySelector: () => null,
+}) {
     let listener;
     const context = vm.createContext({
         browser: {
@@ -20,13 +26,7 @@ function contentHarness() {
                 onMessage: { addListener: (value) => { listener = value; } },
             },
         },
-        document: {
-            activeElement: null,
-            body: { innerText: "" },
-            createTreeWalker: () => ({ nextNode: () => null }),
-            elementFromPoint: () => null,
-            querySelector: () => null,
-        },
+        document,
         setTimeout,
         clearTimeout,
         window: {},
@@ -42,6 +42,8 @@ function backgroundHarness(contentResponse) {
     const contentResponses = Array.isArray(contentResponse)
         ? [...contentResponse]
         : [contentResponse];
+    const tabUpdates = [];
+    const windowUpdates = [];
     const browser = {
         alarms: {
             create() {},
@@ -57,8 +59,12 @@ function backgroundHarness(contentResponse) {
             session: { get: async () => ({}), set() {}, remove: async () => {} },
         },
         tabs: {
-            get: async () => ({ id: 1 }),
+            get: async () => ({ id: 1, windowId: 7 }),
             sendMessage: async () => contentResponses.shift(),
+            update: async (...args) => { tabUpdates.push(args); },
+        },
+        windows: {
+            update: async (...args) => { windowUpdates.push(args); },
         },
         scripting: { executeScript: async () => {} },
     };
@@ -71,10 +77,13 @@ function backgroundHarness(contentResponse) {
         WebSocket: class { static OPEN = 1; static CONNECTING = 0; },
     });
     vm.runInContext(backgroundSource, context);
-    return (request) => vm.runInContext(
+    const handleRequest = (request) => vm.runInContext(
         `handleRequest(${JSON.stringify(request)})`,
         context
     );
+    handleRequest.tabUpdates = tabUpdates;
+    handleRequest.windowUpdates = windowUpdates;
+    return handleRequest;
 }
 
 test("content errors identify stale UIDs and missing targets", async () => {
@@ -140,4 +149,51 @@ test("background reinjects when Safari returns no content response", async () =>
 
     assert.equal(response.errorCode, "stale_uid");
     assert.equal(response.recoveryAction, "take_snapshot");
+});
+
+test("native input preparation focuses only editable text targets", async () => {
+    const document = { activeElement: null };
+    const editor = {
+        contains: (element) => element === editor,
+        disabled: false,
+        focus: () => { document.activeElement = editor; },
+        isContentEditable: true,
+        readOnly: false,
+        scrollIntoView() {},
+        tagName: "DIV",
+    };
+    document.querySelector = () => editor;
+    const call = contentHarness(document);
+
+    const focused = await call("prepare_native_input", { selector: "#editor" });
+    assert.equal(focused.error, null);
+    assert.equal(focused.data, "Focused <div> for native typing");
+
+    document.querySelector = () => ({
+        disabled: false,
+        isContentEditable: false,
+        readOnly: false,
+        tagName: "BUTTON",
+    });
+    const unsupported = await call("prepare_native_input", { selector: "button" });
+    assert.equal(unsupported.errorCode, "unsupported_native_target");
+    assert.equal(unsupported.recoveryAction, "use_synthetic_input");
+});
+
+test("native input preparation foregrounds the target Safari tab", async () => {
+    const handleRequest = backgroundHarness({ data: "Focused", error: null });
+    const response = await handleRequest({
+        id: "request-1",
+        action: "native_type_text",
+        params: { tabId: 1, selector: "#editor", text: "/hello" },
+    });
+
+    assert.equal(response.success, true);
+    assert.equal(response.data, "Safari is ready for native input");
+    assert.equal(handleRequest.tabUpdates.length, 1);
+    assert.equal(handleRequest.tabUpdates[0][0], 1);
+    assert.equal(handleRequest.tabUpdates[0][1].active, true);
+    assert.equal(handleRequest.windowUpdates.length, 1);
+    assert.equal(handleRequest.windowUpdates[0][0], 7);
+    assert.equal(handleRequest.windowUpdates[0][1].focused, true);
 });

--- a/Tests/Fixtures/native-input.html
+++ b/Tests/Fixtures/native-input.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Native input fixture</title>
+</head>
+<body>
+    <div id="editor" contenteditable="true" role="textbox"></div>
+    <script>
+        window.inputEvents = [];
+        const editor = document.querySelector("#editor");
+        for (const type of ["keydown", "beforeinput", "input", "keyup"]) {
+            editor.addEventListener(type, (event) => {
+                window.inputEvents.push({
+                    type,
+                    key: event.key || null,
+                    data: event.data || null,
+                    inputType: event.inputType || null,
+                });
+            });
+        }
+        editor.addEventListener("keydown", (event) => {
+            if (event.key === "/") editor.dataset.slashMenu = "opened";
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- preserve PR #26's structured tool failures, then add `type_text(native: true)` for real macOS keyboard events
- foreground Safari and focus a validated editable target before posting text, optional clear-first, Enter, or Tab
- keep synthetic typing as the default, permission-free path; return actionable Accessibility and focus failures for native mode
- add a compact host-app shortcut to Accessibility settings with copy explaining that permission belongs to the MCP client host
- run Swift tests in CI and add focused extension, host UI, and localhost fixture coverage

## Dependency

This is stacked on #26. Please review and merge #26 first; after it lands, this PR will contain only the native-input commit.

## Verification

- `swift test` (4 tests)
- `node --test Tests/*.mjs`
- release MCP server build
- signed Xcode Debug build and `codesign --verify --deep --strict`
- real Safari fixture: native `/hello` produced `keydown`, `beforeinput`, `input`, and `keyup`, and opened the slash-menu marker
- real Safari fixture: `clearFirst`, native Enter, native Tab, and default synthetic typing passed
- structured invalid-submit-key and missing-target failures passed

Accessibility remains optional. Users who do not grant it continue to use the existing synthetic `type_text` behavior.
