### PR TITLE
feat: add trace event filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ xcuserdata/
 
 # MCP config (contains local paths)
 .mcp.json
+.env
 
 # Claude
 .claude/

--- a/MCPSafari/MCPSafari Extension/Resources/trace-interceptor.js
+++ b/MCPSafari/MCPSafari Extension/Resources/trace-interceptor.js
@@ -60,6 +60,7 @@
     }
 
     function pushEvent(trace, type, detail = {}, at = now()) {
+        if (trace.eventTypes && !trace.eventTypes.has(type)) return;
         if (trace.events.length >= MAX_EVENTS) {
             if (!trace.truncated) {
                 trace.truncated = true;
@@ -186,6 +187,7 @@
             startTime,
             startUrl: location.href,
             events: [],
+            eventTypes: Array.isArray(params.eventTypes) ? new Set(params.eventTypes) : null,
             truncated: false,
         };
 

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -67,8 +67,13 @@ actor SafariMCPServer {
     private static let waitTimeout: Value = .object(["type": .string("number"), "description": .string("Post-action wait timeout seconds (default: 10)")])
     private static let trace: Value = .object(["type": .string("boolean"), "description": .string("Capture page trace events during and shortly after action")])
     private static let traceDuration: Value = .object(["type": .string("number"), "description": .string("Seconds to continue trace capture after action and waits (default: 2, max: 30)")])
+    private static let eventTypes: Value = .object([
+        "type": .string("array"),
+        "items": .object(["type": .string("string"), "minLength": .int(1)]),
+        "description": .string("Exact trace event types to capture (for example dom.mutation, network.fetch, console.error); omitted captures all"),
+    ])
     private static let postActionWaitKeys: Set<String> = ["waitForSelector", "waitForText", "waitTimeout"]
-    private static let postActionTraceKeys: Set<String> = ["trace", "traceDuration"]
+    private static let postActionTraceKeys: Set<String> = ["trace", "traceDuration", "eventTypes"]
     private static let actionControlKeys: Set<String> = postActionWaitKeys.union(postActionTraceKeys)
 
     private static func withPostActionWait(_ properties: [String: Value]) -> [String: Value] {
@@ -83,6 +88,7 @@ actor SafariMCPServer {
         var props = Self.withPostActionWait(properties)
         props["trace"] = Self.trace
         props["traceDuration"] = Self.traceDuration
+        props["eventTypes"] = Self.eventTypes
         return props
     }
 
@@ -781,6 +787,13 @@ actor SafariMCPServer {
 
         var params: [String: AnyCodable] = [:]
         if let tabId = args["tabId"]?.intValue { params["tabId"] = AnyCodable(tabId) }
+        if let value = args["eventTypes"] {
+            guard let values = value.arrayValue,
+                  values.allSatisfy({ $0.stringValue?.isEmpty == false }) else {
+                throw ToolInputError("eventTypes must be an array of non-empty strings")
+            }
+            params["eventTypes"] = AnyCodable(values.compactMap(\.stringValue))
+        }
 
         let response = try await bridge.send(action: "start_trace", params: params)
         guard response.success else { throw ToolInputError(responseText(response)) }

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ Most interaction tools support `includeSnapshot: true`, which returns the update
 
 ### Page Traces
 
-Interaction tools support `trace: true` and `traceDuration` to return a short page trace after the action. Traces include URL/history changes, console messages, fetch/XHR requests, and DOM mutations captured during the action window.
+Interaction tools support `trace: true` and `traceDuration` to return a short page trace after the action. Use `eventTypes` for an exact-match allowlist such as `["dom.mutation", "network.fetch"]`; omit it to capture all URL/history, console, fetch/XHR, and DOM mutation events during the action window.
 
 ## Architecture
 

--- a/Tests/trace-interceptor.test.mjs
+++ b/Tests/trace-interceptor.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/trace-interceptor.js", import.meta.url),
+    "utf8"
+);
+
+function loadInterceptor() {
+    const location = { href: "https://example.test/" };
+    const window = {
+        CSS: { escape: String },
+        addEventListener() {},
+        postMessage() {},
+    };
+
+    class MutationObserver {
+        observe() {}
+        disconnect() {}
+    }
+
+    vm.runInNewContext(source, {
+        window,
+        location,
+        history: { pushState() {}, replaceState() {} },
+        document: { documentElement: {} },
+        MutationObserver,
+        Node: { ELEMENT_NODE: 1 },
+        setInterval: () => 1,
+        clearInterval() {},
+    });
+
+    return window;
+}
+
+test("eventTypes filters before the trace event cap", () => {
+    const window = loadInterceptor();
+    const { id } = window.__mcpStartTrace({ eventTypes: ["network.fetch"] });
+
+    for (let index = 0; index <= 1000; index += 1) {
+        window.__mcpRecordTraceEvent("dom.mutation", { index });
+    }
+    window.__mcpRecordTraceEvent("network.fetch", { url: "https://example.test/data" });
+
+    const trace = window.__mcpStopTrace({ id });
+    assert.equal(trace.truncated, false);
+    assert.deepEqual(
+        Array.from(trace.events, ({ type }) => type),
+        ["network.fetch"]
+    );
+});


### PR DESCRIPTION
## Summary

- add an `eventTypes` exact-match allowlist to trace-capable interaction tools
- filter unwanted events before they consume the shared 1,000-event trace cap
- document the option and cover cap preservation with a focused Node regression test
- ignore `.env` files as repository hygiene

## Why

Busy pages can fill a trace with unrelated DOM mutations before the relevant console or network event occurs. Filtering at the shared event insertion point preserves the cap for requested evidence while keeping unfiltered traces backward compatible.

## Validation

- `node --test Tests/*.mjs`
- `swift test`
- `swift build -c release`
- unsigned Xcode Debug app and extension build; verified the packaged extension contains the filter
- direct MCP smoke for advertised schema and malformed `eventTypes` validation
- gitleaks 8.30.1 scan of the staged diff
