### PR TITLE
fix: retry trace startup after interceptor timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Bug Fixes
 - Fixed `snapshot` crashing on SVG elements with non-string `type` properties.
+- Retried trace startup once after an interceptor timeout so a transient `start_trace interceptor did not respond` failure no longer aborts the traced action.
 
 ### Build
 - Updated SwiftPM dependencies, including MCP Swift SDK 0.12.1, SwiftLog 1.14.0, and SwiftNIO 2.101.3.

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -787,8 +787,22 @@
     // --- Page Trace (delegate to interceptor) ------------------------
 
     async function startTrace(params) {
-        const trace = await requestMainWorld("start_trace", params);
-        return trace.id;
+        // Fixed trace id across attempts: if the interceptor processes the
+        // first request late, the retry overwrites the same trace instead of
+        // double-starting one.
+        const request = { ...params, id: `trace-${Date.now()}-${++bridgeRequestCounter}` };
+        try {
+            const trace = await requestMainWorld("start_trace", request);
+            return trace.id;
+        } catch (err) {
+            // The MAIN-world interceptor can miss a request sent right after
+            // navigation, before its listener is ready. Retry once so a
+            // transient startup timeout does not abort the traced action.
+            if (!String(err.message || err).endsWith("interceptor did not respond")) throw err;
+            await new Promise((resolve) => setTimeout(resolve, 250));
+            const trace = await requestMainWorld("start_trace", request);
+            return trace.id;
+        }
     }
 
     async function stopTrace(params) {

--- a/Tests/content-trace-startup.test.mjs
+++ b/Tests/content-trace-startup.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+// Loads content.js with a controllable clock and a fake MAIN-world bridge so
+// tests can decide which start_trace requests the interceptor answers.
+function loadContent() {
+    let runtimeListener;
+    const messageListeners = new Set();
+    const posted = [];
+    const timers = [];
+
+    const window = {
+        addEventListener: (type, fn) => {
+            if (type === "message") messageListeners.add(fn);
+        },
+        removeEventListener: (type, fn) => {
+            if (type === "message") messageListeners.delete(fn);
+        },
+        postMessage: (message) => posted.push(message),
+    };
+
+    vm.runInNewContext(source, {
+        browser: {
+            runtime: {
+                onMessage: { addListener: (fn) => { runtimeListener = fn; } },
+            },
+        },
+        document: {},
+        setTimeout: (fn) => timers.push({ fn }) - 1,
+        clearTimeout: (id) => { if (timers[id]) timers[id].fn = null; },
+        window,
+    });
+
+    return {
+        call: (action, params) => new Promise((resolve) => {
+            runtimeListener({ action, params }, {}, resolve);
+        }),
+        posted,
+        fireNextTimer: () => {
+            const timer = timers.shift();
+            if (timer?.fn) timer.fn();
+        },
+        respond: (id, payload) => {
+            for (const listener of messageListeners) {
+                listener({ source: window, data: { source: "MCPSafariPage", id, ...payload } });
+            }
+        },
+        flush: () => new Promise((resolve) => setImmediate(resolve)),
+    };
+}
+
+test("start_trace retries once after an interceptor startup timeout", async () => {
+    const page = loadContent();
+    const result = page.call("start_trace", {});
+
+    await page.flush();
+    assert.equal(page.posted.length, 1);
+
+    page.fireNextTimer(); // first request's 3s timeout fires unanswered
+    await page.flush();
+    page.fireNextTimer(); // 250ms retry delay
+    await page.flush();
+
+    assert.equal(page.posted.length, 2);
+    assert.equal(page.posted[0].params.id, page.posted[1].params.id);
+    page.respond(page.posted[1].id, { data: { id: page.posted[1].params.id } });
+
+    const response = await result;
+    assert.equal(response.data, page.posted[1].params.id);
+    assert.equal(response.error, null);
+});
+
+test("start_trace does not retry interceptor-reported errors", async () => {
+    const page = loadContent();
+    const result = page.call("start_trace", {});
+
+    await page.flush();
+    assert.equal(page.posted.length, 1);
+    page.respond(page.posted[0].id, { error: "Trace already running" });
+
+    const response = await result;
+    assert.equal(response.data, null);
+    assert.equal(response.error, "Trace already running");
+    assert.equal(page.posted.length, 1);
+});
+
+test("start_trace fails after the retry also times out", async () => {
+    const page = loadContent();
+    const result = page.call("start_trace", {});
+
+    await page.flush();
+    page.fireNextTimer(); // first timeout
+    await page.flush();
+    page.fireNextTimer(); // retry delay
+    await page.flush();
+    page.fireNextTimer(); // retry timeout
+    await page.flush();
+
+    const response = await result;
+    assert.equal(response.data, null);
+    assert.equal(response.error, "start_trace interceptor did not respond");
+    assert.equal(page.posted.length, 2);
+});


### PR DESCRIPTION
## Problem

Enabling tracing on an interaction can fail before the action runs:

```
start_trace interceptor did not respond
```

The request shape is valid and the same call succeeds with `trace=false`, so turning on diagnostics prevents the very interaction being diagnosed. Observed on v0.2.9 during localhost QA: a traced UID click failed with this error, and the identical click without trace ran immediately.

## Root cause

`content.js` forwards `start_trace` to the MAIN-world trace interceptor over `postMessage` with a single 3-second timeout. Both scripts inject at `document_start`, but right after a navigation the interceptor's message listener can miss the first request, so the one-shot request times out and the whole tool call aborts before the action executes.

## Fix

`startTrace` in `content.js` retries the interceptor request once after 250 ms, only when the failure is the startup timeout. Interceptor-reported errors still fail immediately without a retry, and the error text is unchanged when both attempts time out. No server or schema changes.

Both attempts carry the same caller-generated trace id (`__mcpStartTrace` already accepts `params.id`), so if the interceptor processes the first request late, the retry overwrites the same `traces` entry instead of double-starting a trace; event fan-out iterates `traces.values()`, so the replaced entry stops receiving events.

## Validation

- New `Tests/content-trace-startup.test.mjs` (Node VM harness): retries once after a startup timeout, does not retry interceptor-reported errors, fails with the original message after the retry also times out.
- `node --test Tests/*.mjs` — all tests pass, including the existing trace-interceptor suite.
- `node --check` on `content.js`.
- CI-equivalent unsigned Debug `xcodebuild` build succeeded.
