### PR TITLE
feat: add file upload and drop tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added a backward-compatible versioned extension/server handshake with explicit protocol mismatch errors.
 - Tool failures now include stable error codes, retry guidance, and recovery actions for disconnected bridges, stale element UIDs, missing targets, and wait timeouts.
 - `type_text` now supports opt-in native macOS keyboard events for contenteditable and framework-managed editors.
+- Added `upload_file` and `drop_file` for attaching explicit local files to a file input or dropping them onto an element.
 
 ### Bug Fixes
 - Stop stale per-port token files from causing endless extension reconnect attempts and popup state cycling.

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -272,6 +272,8 @@ async function handleRequest(request) {
             case "press_key":
             case "hover":
             case "drag":
+            case "upload_file":
+            case "drop_file":
             case "wait":
             case "start_trace":
             case "stop_trace":

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -117,6 +117,10 @@
                 return hoverElement(params);
             case "drag":
                 return dragElement(params);
+            case "upload_file":
+                return uploadFile(params);
+            case "drop_file":
+                return dropFile(params);
             case "wait":
                 return waitFor(params);
             case "start_trace":
@@ -842,6 +846,88 @@
         fromEl.dispatchEvent(new MouseEvent("mouseup", { ...baseOpts, clientX: toX, clientY: toY }));
 
         return `Dragged <${fromEl.tagName.toLowerCase()}> to <${toEl.tagName.toLowerCase()}>`;
+    }
+
+    // ─── File Attachment ─────────────────────────────────────────────
+
+    function buildFiles(params) {
+        const specs = params.files || [];
+        if (specs.length === 0) throw new Error("No files provided");
+
+        return specs.map((spec) => {
+            const binary = atob(spec.data);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i += 1) {
+                bytes[i] = binary.charCodeAt(i);
+            }
+            return new File([bytes], spec.name, { type: spec.type });
+        });
+    }
+
+    function transferFor(files) {
+        const dataTransfer = new DataTransfer();
+        for (const file of files) dataTransfer.items.add(file);
+        return dataTransfer;
+    }
+
+    function describeFiles(files) {
+        return files.map((file) => file.name).join(", ");
+    }
+
+    // Accepts the input itself, a wrapper element around it, or its <label>.
+    function resolveFileInput(element) {
+        if (element.tagName && element.tagName.toLowerCase() === "input" && element.type === "file") {
+            return element;
+        }
+        if (element.control && element.control.type === "file") {
+            return element.control;
+        }
+        const nested = element.querySelector && element.querySelector('input[type="file"]');
+        if (nested) return nested;
+
+        throw new Error(
+            `<${element.tagName ? element.tagName.toLowerCase() : "element"}> is not a file input and contains none. Target the <input type="file"> directly, or use drop_file for a drop zone.`
+        );
+    }
+
+    function uploadFile(params) {
+        const target = resolveElement({ uid: params.uid, selector: params.selector });
+        const input = resolveFileInput(target);
+        const files = buildFiles(params);
+
+        if (files.length > 1 && !input.multiple) {
+            throw new Error(`Input accepts one file but ${files.length} were provided`);
+        }
+        if (input.disabled) throw new Error("File input is disabled");
+
+        input.files = transferFor(files).files;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+
+        return `Attached ${describeFiles(files)} to file input`;
+    }
+
+    function dropFile(params) {
+        const target = resolveElement({ uid: params.uid, selector: params.selector });
+        const files = buildFiles(params);
+        const dataTransfer = transferFor(files);
+
+        target.scrollIntoView({ behavior: "instant", block: "center" });
+        const rect = target.getBoundingClientRect();
+        const baseOpts = {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+            dataTransfer,
+        };
+
+        for (const type of ["dragenter", "dragover", "drop"]) {
+            target.dispatchEvent(new DragEvent(type, baseOpts));
+        }
+
+        return `Dropped ${describeFiles(files)} on <${target.tagName.toLowerCase()}>`;
     }
 
     // ─── Wait ────────────────────────────────────────────────────────

--- a/MCPServer/Sources/mcp-safari/FileAttachment.swift
+++ b/MCPServer/Sources/mcp-safari/FileAttachment.swift
@@ -1,0 +1,88 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// One caller-provided local file, staged for delivery to the page as a browser `File`.
+struct FileAttachment: Equatable, Sendable {
+    let name: String
+    let mimeType: String
+    let base64: String
+}
+
+struct FileAttachmentError: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}
+
+/// Reads explicit caller-provided paths into base64 payloads for the extension bridge.
+///
+/// Only paths named by the caller are read. Limits are conservative because the whole
+/// payload travels as one JSON WebSocket message to the extension.
+enum FileAttachmentLoader {
+    static let maxFileCount = 10
+    static let maxTotalBytes = 10 * 1024 * 1024
+
+    static func load(paths: [String], mimeTypeOverride: String? = nil) throws -> [FileAttachment] {
+        guard !paths.isEmpty else {
+            throw FileAttachmentError("Provide filePath or filePaths")
+        }
+        guard paths.count <= maxFileCount else {
+            throw FileAttachmentError("Too many files: \(paths.count). Maximum is \(maxFileCount) per call.")
+        }
+
+        var attachments: [FileAttachment] = []
+        var totalBytes = 0
+
+        for path in paths {
+            let url = try resolve(path)
+            let data: Data
+            do {
+                data = try Data(contentsOf: url)
+            } catch {
+                throw FileAttachmentError("Cannot read file: \(url.path) (\(error.localizedDescription))")
+            }
+
+            totalBytes += data.count
+            guard totalBytes <= maxTotalBytes else {
+                throw FileAttachmentError(
+                    "Files exceed the \(maxTotalBytes / (1024 * 1024)) MB total limit for one call"
+                )
+            }
+
+            attachments.append(
+                FileAttachment(
+                    name: url.lastPathComponent,
+                    mimeType: mimeTypeOverride ?? mimeType(for: url),
+                    base64: data.base64EncodedString()
+                )
+            )
+        }
+
+        return attachments
+    }
+
+    private static func resolve(_ path: String) throws -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw FileAttachmentError("File path must not be empty")
+        }
+
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded).standardizedFileURL
+
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
+            throw FileAttachmentError("File not found: \(url.path)")
+        }
+        guard !isDirectory.boolValue else {
+            throw FileAttachmentError("Path is a directory, not a file: \(url.path)")
+        }
+        return url
+    }
+
+    private static func mimeType(for url: URL) -> String {
+        UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+    }
+}

--- a/MCPServer/Sources/mcp-safari/FileAttachment.swift
+++ b/MCPServer/Sources/mcp-safari/FileAttachment.swift
@@ -36,7 +36,15 @@ enum FileAttachmentLoader {
         var totalBytes = 0
 
         for path in paths {
-            let url = try resolve(path)
+            let (url, name, reportedSize) = try resolve(path)
+            // Reject on the reported size before reading so an oversized path cannot be
+            // loaded into memory first.
+            guard reportedSize <= maxTotalBytes - totalBytes else {
+                throw FileAttachmentError(
+                    "Files exceed the \(maxTotalBytes / (1024 * 1024)) MB total limit for one call"
+                )
+            }
+
             let data: Data
             do {
                 data = try Data(contentsOf: url)
@@ -44,6 +52,7 @@ enum FileAttachmentLoader {
                 throw FileAttachmentError("Cannot read file: \(url.path) (\(error.localizedDescription))")
             }
 
+            // Re-check after reading in case the file grew between the two checks.
             totalBytes += data.count
             guard totalBytes <= maxTotalBytes else {
                 throw FileAttachmentError(
@@ -53,8 +62,8 @@ enum FileAttachmentLoader {
 
             attachments.append(
                 FileAttachment(
-                    name: url.lastPathComponent,
-                    mimeType: mimeTypeOverride ?? mimeType(for: url),
+                    name: name,
+                    mimeType: mimeTypeOverride ?? mimeType(forName: name),
                     base64: data.base64EncodedString()
                 )
             )
@@ -63,26 +72,42 @@ enum FileAttachmentLoader {
         return attachments
     }
 
-    private static func resolve(_ path: String) throws -> URL {
+    /// Resolves a caller path to a regular file, its attachment name, and its reported size.
+    ///
+    /// Checks and reads follow symlinks so they describe the file that is actually read,
+    /// while the attachment keeps the name the caller asked for. Only regular files are
+    /// accepted: a FIFO, socket, or device path would otherwise block or stream without
+    /// end once `Data(contentsOf:)` opened it.
+    private static func resolve(_ path: String) throws -> (url: URL, name: String, size: Int) {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw FileAttachmentError("File path must not be empty")
         }
 
         let expanded = (trimmed as NSString).expandingTildeInPath
-        let url = URL(fileURLWithPath: expanded).standardizedFileURL
+        let requested = URL(fileURLWithPath: expanded).standardizedFileURL
+        let url = requested.resolvingSymlinksInPath()
 
-        var isDirectory: ObjCBool = false
-        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory) else {
-            throw FileAttachmentError("File not found: \(url.path)")
+        let values: URLResourceValues
+        do {
+            values = try url.resourceValues(forKeys: [.isRegularFileKey, .isDirectoryKey, .fileSizeKey])
+        } catch {
+            throw FileAttachmentError("Cannot access file: \(url.path) (\(error.localizedDescription))")
         }
-        guard !isDirectory.boolValue else {
+
+        if values.isDirectory == true {
             throw FileAttachmentError("Path is a directory, not a file: \(url.path)")
         }
-        return url
+        guard values.isRegularFile == true else {
+            throw FileAttachmentError("Path is not a regular file: \(url.path)")
+        }
+        guard let size = values.fileSize else {
+            throw FileAttachmentError("Cannot determine file size: \(url.path)")
+        }
+        return (url, requested.lastPathComponent, size)
     }
 
-    private static func mimeType(for url: URL) -> String {
-        UTType(filenameExtension: url.pathExtension)?.preferredMIMEType ?? "application/octet-stream"
+    private static func mimeType(forName name: String) -> String {
+        UTType(filenameExtension: (name as NSString).pathExtension)?.preferredMIMEType ?? "application/octet-stream"
     }
 }

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -620,17 +620,27 @@ actor SafariMCPServer {
     /// Reads the caller's local files, then runs the interaction with them attached.
     private func handleFileAction(_ action: String, _ args: [String: Value]) async throws -> CallTool.Result {
         var paths: [String] = []
-        if let path = args["filePath"]?.stringValue { paths.append(path) }
-        if let values = args["filePaths"]?.arrayValue {
+        if let filePath = args["filePath"] {
+            guard let path = filePath.stringValue else { throw ToolInputError("filePath must be a string") }
+            paths.append(path)
+        }
+        if let filePaths = args["filePaths"] {
+            guard let values = filePaths.arrayValue else { throw ToolInputError("filePaths must be an array of strings") }
             for value in values {
                 guard let path = value.stringValue else { throw ToolInputError("filePaths must be an array of strings") }
                 paths.append(path)
             }
         }
 
+        var mimeTypeOverride: String?
+        if let mimeType = args["mimeType"] {
+            guard let value = mimeType.stringValue else { throw ToolInputError("mimeType must be a string") }
+            mimeTypeOverride = value
+        }
+
         let attachments: [FileAttachment]
         do {
-            attachments = try FileAttachmentLoader.load(paths: paths, mimeTypeOverride: args["mimeType"]?.stringValue)
+            attachments = try FileAttachmentLoader.load(paths: paths, mimeTypeOverride: mimeTypeOverride)
         } catch let error as FileAttachmentError {
             throw ToolInputError(error.description)
         }

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -79,6 +79,14 @@ actor SafariMCPServer {
         "items": .object(["type": .string("string"), "minLength": .int(1)]),
         "description": .string("Exact trace event types to capture (for example dom.mutation, network.fetch, console.error); omitted captures all"),
     ])
+    private static let filePath: Value = .object(["type": .string("string"), "description": .string("Local file path (~ expanded)")])
+    private static let filePaths: Value = .object([
+        "type": .string("array"),
+        "items": .object(["type": .string("string"), "minLength": .int(1)]),
+        "description": .string("Local file paths, up to \(FileAttachmentLoader.maxFileCount) and \(FileAttachmentLoader.maxTotalBytes / (1024 * 1024)) MB per call"),
+    ])
+    private static let mimeType: Value = .object(["type": .string("string"), "description": .string("Override the MIME type inferred from the file extension")])
+    private static let fileInputKeys: Set<String> = ["filePath", "filePaths", "mimeType"]
     private static let postActionWaitKeys: Set<String> = ["waitForSelector", "waitForText", "waitTimeout"]
     private static let postActionTraceKeys: Set<String> = ["trace", "traceDuration", "eventTypes"]
     private static let actionControlKeys: Set<String> = postActionWaitKeys.union(postActionTraceKeys)
@@ -327,6 +335,30 @@ actor SafariMCPServer {
                 ])
             ),
             Tool(
+                name: "upload_file",
+                description: "Attach local files to a file input.",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object(Self.withActionOptions([
+                        "uid": Self.uid, "selector": Self.sel,
+                        "filePath": Self.filePath, "filePaths": Self.filePaths, "mimeType": Self.mimeType,
+                        "includeSnapshot": Self.snap, "tabId": Self.tab,
+                    ])),
+                ])
+            ),
+            Tool(
+                name: "drop_file",
+                description: "Drop local files onto an element (dragenter/dragover/drop).",
+                inputSchema: .object([
+                    "type": .string("object"),
+                    "properties": .object(Self.withActionOptions([
+                        "uid": Self.uid, "selector": Self.sel,
+                        "filePath": Self.filePath, "filePaths": Self.filePaths, "mimeType": Self.mimeType,
+                        "includeSnapshot": Self.snap, "tabId": Self.tab,
+                    ])),
+                ])
+            ),
+            Tool(
                 name: "handle_dialog",
                 description: "Accept/dismiss alert, confirm, or prompt dialog.",
                 inputSchema: .object([
@@ -447,6 +479,8 @@ actor SafariMCPServer {
             case "press_key":       return try await handleInteraction("press_key", args)
             case "hover":           return try await handleInteraction("hover", args)
             case "drag":            return try await handleInteraction("drag", args)
+            case "upload_file":     return try await handleFileAction("upload_file", args)
+            case "drop_file":       return try await handleFileAction("drop_file", args)
             case "handle_dialog":   return try await handleInteraction("handle_dialog", args)
             case "screenshot":      return try await handleScreenshot(args)
             case "javascript_tool": return try await handleJavaScript(args)
@@ -583,11 +617,53 @@ actor SafariMCPServer {
         return textResult(response)
     }
 
+    /// Reads the caller's local files, then runs the interaction with them attached.
+    private func handleFileAction(_ action: String, _ args: [String: Value]) async throws -> CallTool.Result {
+        var paths: [String] = []
+        if let path = args["filePath"]?.stringValue { paths.append(path) }
+        if let values = args["filePaths"]?.arrayValue {
+            for value in values {
+                guard let path = value.stringValue else { throw ToolInputError("filePaths must be an array of strings") }
+                paths.append(path)
+            }
+        }
+
+        let attachments: [FileAttachment]
+        do {
+            attachments = try FileAttachmentLoader.load(paths: paths, mimeTypeOverride: args["mimeType"]?.stringValue)
+        } catch let error as FileAttachmentError {
+            throw ToolInputError(error.description)
+        }
+
+        let files = attachments.map { attachment in
+            AnyCodable([
+                "name": AnyCodable(attachment.name),
+                "type": AnyCodable(attachment.mimeType),
+                "data": AnyCodable(attachment.base64),
+            ] as [String: AnyCodable])
+        }
+
+        return try await handleInteraction(
+            action,
+            args,
+            extraParams: ["files": AnyCodable(files)],
+            skipKeys: Self.fileInputKeys
+        )
+    }
+
     /// Unified handler for interaction tools: click, type_text, hover, scroll, press_key, select_option, drag.
     /// Forwards all params to the extension and optionally appends a snapshot.
-    private func handleInteraction(_ action: String, _ args: [String: Value]) async throws -> CallTool.Result {
-        let params = interactionParams(args)
+    private func handleInteraction(
+        _ action: String,
+        _ args: [String: Value],
+        extraParams: [String: AnyCodable] = [:],
+        skipKeys: Set<String> = []
+    ) async throws -> CallTool.Result {
+        var params = interactionParams(args, skipKeys: skipKeys)
         let wantSnapshot = args["includeSnapshot"]?.boolValue == true
+
+        // Server-supplied params win over forwarded caller args.
+        params.merge(extraParams) { _, supplied in supplied }
 
         let traceSession = try await startTraceIfNeeded(args)
         do {
@@ -601,10 +677,11 @@ actor SafariMCPServer {
         }
     }
 
-    private func interactionParams(_ args: [String: Value]) -> [String: AnyCodable] {
+    private func interactionParams(_ args: [String: Value], skipKeys: Set<String> = []) -> [String: AnyCodable] {
         var params: [String: AnyCodable] = [:]
         for (key, value) in args {
             if key == "includeSnapshot" || key == "tabId" || Self.actionControlKeys.contains(key) { continue }
+            if skipKeys.contains(key) { continue }
             if let s = value.stringValue { params[key] = AnyCodable(s) }
             else if let i = value.intValue { params[key] = AnyCodable(i) }
             else if let d = value.doubleValue { params[key] = AnyCodable(d) }

--- a/MCPServer/Tests/MCPSafariTests/FileAttachmentTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/FileAttachmentTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import MCPSafari
+
+struct FileAttachmentTests {
+    @Test func readsFilesAndInfersMimeTypeFromExtension() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let pngBytes = Data([137, 80, 78, 71])
+        let png = root.appendingPathComponent("shot.png")
+        try pngBytes.write(to: png)
+        let unknown = root.appendingPathComponent("payload.unknown-extension")
+        try Data([1, 2]).write(to: unknown)
+
+        let attachments = try FileAttachmentLoader.load(paths: [png.path, unknown.path])
+
+        #expect(attachments.count == 2)
+        #expect(
+            attachments[0] == FileAttachment(
+                name: "shot.png",
+                mimeType: "image/png",
+                base64: pngBytes.base64EncodedString()
+            )
+        )
+        #expect(attachments[1].mimeType == "application/octet-stream")
+    }
+
+    @Test func mimeTypeOverrideWins() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let file = root.appendingPathComponent("note.txt")
+        try Data("hi".utf8).write(to: file)
+
+        let attachments = try FileAttachmentLoader.load(paths: [file.path], mimeTypeOverride: "text/markdown")
+
+        #expect(attachments[0].mimeType == "text/markdown")
+    }
+
+    @Test func rejectsMissingPathsDirectoriesAndEmptyInput() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [])
+        }
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [root.appendingPathComponent("nope.png").path])
+        }
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [root.path])
+        }
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: ["   "])
+        }
+    }
+
+    @Test func enforcesCountAndTotalSizeLimits() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let small = root.appendingPathComponent("small.bin")
+        try Data([0]).write(to: small)
+        let tooMany = Array(repeating: small.path, count: FileAttachmentLoader.maxFileCount + 1)
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: tooMany)
+        }
+
+        let large = root.appendingPathComponent("large.bin")
+        try Data(count: FileAttachmentLoader.maxTotalBytes + 1).write(to: large)
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [large.path])
+        }
+    }
+
+    private func makeDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}

--- a/MCPServer/Tests/MCPSafariTests/FileAttachmentTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/FileAttachmentTests.swift
@@ -74,6 +74,69 @@ struct FileAttachmentTests {
         }
     }
 
+    /// A FIFO never reaches EOF, so this hangs instead of failing if the loader ever
+    /// opens a path before confirming it is a regular file.
+    @Test func rejectsNonRegularFilesWithoutReadingThem() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let fifo = root.appendingPathComponent("pipe")
+        #expect(mkfifo(fifo.path, 0o600) == 0)
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [fifo.path])
+        }
+
+        let link = root.appendingPathComponent("pipe-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: fifo)
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [link.path])
+        }
+    }
+
+    /// The page should see the name the caller asked for, even when that path is a link.
+    @Test func keepsTheRequestedNameWhenThePathIsASymlink() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let target = root.appendingPathComponent("generated-1234.png")
+        try Data([137, 80, 78, 71]).write(to: target)
+        let link = root.appendingPathComponent("latest.png")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        let attachments = try FileAttachmentLoader.load(paths: [link.path])
+
+        #expect(attachments[0].name == "latest.png")
+        #expect(attachments[0].mimeType == "image/png")
+    }
+
+    /// Sparse files keep this fast: rejection has to come from the reported size, not
+    /// from bytes already loaded into memory.
+    @Test func rejectsOversizedAndBudgetExceedingFilesByReportedSize() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let huge = try makeSparseFile(at: root.appendingPathComponent("huge.bin"), size: 4 * 1024 * 1024 * 1024)
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [huge.path])
+        }
+
+        // Two files that each fit but together exceed the per-call total.
+        let half = FileAttachmentLoader.maxTotalBytes * 2 / 3
+        let first = try makeSparseFile(at: root.appendingPathComponent("first.bin"), size: half)
+        let second = try makeSparseFile(at: root.appendingPathComponent("second.bin"), size: half)
+        #expect(throws: FileAttachmentError.self) {
+            try FileAttachmentLoader.load(paths: [first.path, second.path])
+        }
+    }
+
+    private func makeSparseFile(at url: URL, size: Int) throws -> URL {
+        FileManager.default.createFile(atPath: url.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.truncate(atOffset: UInt64(size))
+        return url
+    }
+
     private func makeDirectory() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ mcp-safari doctor --json
 
 The doctor checks the server executable, app and extension bundles, PlugInKit registration, matching versions, and the selected port's token file. It never returns token contents and does not change system state.
 
-## Tools (24)
+## Tools (26)
 
 ### Diagnostics
 
@@ -262,6 +262,8 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 | `press_key` | Press key combinations (e.g., `Enter`, `Meta+a`, `Control+c`) |
 | `hover` | Hover to trigger tooltips, menus, or hover states |
 | `drag` | Drag and drop between elements |
+| `upload_file` | Attach local files to an `<input type="file">` |
+| `drop_file` | Drop local files onto an element |
 
 > **Note:** Interaction tools drive elements via synthetic DOM events (and React-compatible value setting for text), which works across the vast majority of sites. Because the events are synthetic, `press_key` modifier combos (e.g. `Meta+a`, `Control+c`) and `drag` reach page-level JS handlers but do **not** trigger native browser actions — clipboard copy/paste, select-all, or HTML5 native drag-and-drop. Use `type_text`/`form_input` for text entry and `javascript_tool` when a true native action is required.
 
@@ -340,6 +342,20 @@ Use `form_input` to fill multiple fields at once:
 
 This uses React-compatible value setting (`nativeInputValueSetter`) so it works with controlled inputs in React, Next.js, and similar frameworks.
 
+### File Upload and Drop
+
+`upload_file` attaches local files to a file input, and `drop_file` delivers them to a drop zone:
+
+```json
+{ "selector": "input[type=file]", "filePath": "~/Pictures/reference.png" }
+```
+
+```json
+{ "selector": "#dropzone", "filePaths": ["/tmp/a.pdf", "/tmp/b.pdf"] }
+```
+
+The server reads only the paths you name, infers each MIME type from the file extension (override with `mimeType`), and sends the bytes to the page. `upload_file` accepts the input itself, its `<label>`, or a wrapper containing it, then fires `input` and `change`; `drop_file` dispatches `dragenter`, `dragover`, and `drop` with a `DataTransfer` holding the files. Up to 10 files and 10 MB total per call.
+
 ### Smart Text Matching
 
 When targeting by `text`, interactive elements (buttons, links, inputs) are ranked higher than generic containers. Clicking `text: "Submit"` will prefer a `<button>Submit</button>` over a `<div>Submit</div>`.
@@ -395,6 +411,7 @@ The server generates a random UUID token at startup, writes it to `~/.config/mcp
 - Navigation actions validated against an allowlist
 - Regex patterns capped at 200 characters and validated before forwarding
 - Wait durations capped at 300 seconds
+- File reads limited to explicit caller-provided paths, with directories rejected and 10 files / 10 MB capped per call
 
 ### Permissions
 

--- a/Tests/content-file-attachment.test.mjs
+++ b/Tests/content-file-attachment.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+// Minimal stand-ins for the DOM file APIs content.js uses. Node has File but
+// neither DataTransfer nor DragEvent.
+class FakeDataTransfer {
+    constructor() {
+        this.files = [];
+        this.items = { add: (file) => this.files.push(file) };
+    }
+}
+
+class FakeEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        Object.assign(this, options);
+    }
+}
+
+function makeElement(overrides = {}) {
+    return {
+        tagName: "DIV",
+        events: [],
+        scrollIntoView() {},
+        getBoundingClientRect: () => ({ left: 10, top: 20, width: 100, height: 50 }),
+        querySelector: () => null,
+        dispatchEvent(event) {
+            this.events.push(event);
+            return true;
+        },
+        ...overrides,
+    };
+}
+
+function makeFileInput(overrides = {}) {
+    return makeElement({ tagName: "INPUT", type: "file", files: [], ...overrides });
+}
+
+// Loads content.js against a fake document whose querySelector returns `target`.
+function loadContent(target) {
+    let runtimeListener;
+
+    vm.runInNewContext(source, {
+        browser: {
+            runtime: {
+                onMessage: { addListener: (fn) => { runtimeListener = fn; } },
+            },
+        },
+        document: { querySelector: () => target },
+        window: { addEventListener() {}, postMessage() {} },
+        setTimeout: () => 0,
+        clearTimeout() {},
+        atob,
+        Uint8Array,
+        File,
+        DataTransfer: FakeDataTransfer,
+        Event: FakeEvent,
+        DragEvent: FakeEvent,
+    });
+
+    return (action, params) => new Promise((resolve) => {
+        runtimeListener({ action, params }, {}, resolve);
+    });
+}
+
+const PNG = { name: "shot.png", type: "image/png", data: Buffer.from([137, 80, 78, 71]).toString("base64") };
+const TXT = { name: "note.txt", type: "text/plain", data: Buffer.from("hi").toString("base64") };
+
+test("upload_file assigns decoded files and dispatches input then change", async () => {
+    const input = makeFileInput();
+    const call = loadContent(input);
+
+    const response = await call("upload_file", { selector: "#file", files: [PNG] });
+
+    assert.equal(response.error, null);
+    assert.equal(input.files.length, 1);
+    assert.equal(input.files[0].name, "shot.png");
+    assert.equal(input.files[0].type, "image/png");
+    assert.equal(input.files[0].size, 4);
+    assert.deepEqual(input.events.map((event) => event.type), ["input", "change"]);
+    assert.equal(input.events[0].bubbles, true);
+});
+
+test("upload_file resolves a file input inside a wrapper target", async () => {
+    const input = makeFileInput();
+    const wrapper = makeElement({ querySelector: (selector) => (selector === 'input[type="file"]' ? input : null) });
+    const call = loadContent(wrapper);
+
+    const response = await call("upload_file", { selector: "#dropzone", files: [PNG, TXT] });
+
+    assert.equal(response.error, "Input accepts one file but 2 were provided");
+
+    input.multiple = true;
+    const retry = await call("upload_file", { selector: "#dropzone", files: [PNG, TXT] });
+    assert.equal(retry.error, null);
+    assert.deepEqual(input.files.map((file) => file.name), ["shot.png", "note.txt"]);
+});
+
+test("upload_file rejects targets with no file input", async () => {
+    const call = loadContent(makeElement({ tagName: "BUTTON" }));
+
+    const response = await call("upload_file", { selector: "button", files: [PNG] });
+
+    assert.equal(response.data, null);
+    assert.match(response.error, /is not a file input and contains none/);
+});
+
+test("upload_file rejects an empty file list", async () => {
+    const call = loadContent(makeFileInput());
+
+    const response = await call("upload_file", { selector: "#file", files: [] });
+
+    assert.equal(response.error, "No files provided");
+});
+
+test("drop_file dispatches dragenter, dragover, and drop carrying the files", async () => {
+    const zone = makeElement();
+    const call = loadContent(zone);
+
+    const response = await call("drop_file", { selector: "#zone", files: [PNG] });
+
+    assert.equal(response.error, null);
+    assert.deepEqual(zone.events.map((event) => event.type), ["dragenter", "dragover", "drop"]);
+    for (const event of zone.events) {
+        assert.equal(event.cancelable, true);
+        assert.deepEqual(event.dataTransfer.files.map((file) => file.name), ["shot.png"]);
+        assert.equal(event.clientX, 60);
+        assert.equal(event.clientY, 45);
+    }
+});


### PR DESCRIPTION
Closes #31.

Agents can click an upload button today, but nothing can hand the page an actual
file, so upload and drag-and-drop flows have no Safari coverage.

Two tools, both built on the existing interaction path (UID/selector targeting,
`includeSnapshot`, waits, traces):

- `upload_file({ uid | selector, filePath | filePaths, mimeType? })` — assigns
  the files to an `<input type="file">`, then fires `input` and `change`. Takes
  the input, its `<label>`, or a wrapper around it; errors clearly on anything else.
- `drop_file({ uid | selector, filePath | filePaths, mimeType? })` — dispatches
  `dragenter`/`dragover`/`drop` with a `DataTransfer` carrying the files.

The server reads only the paths the caller passes, expands `~`, rejects missing
files and directories, infers MIME type from the extension, and caps a call at
10 files / 10 MB since the payload is one bridge message. The page builds the
`File` objects.

Good news on the open question in the issue: Safari does allow setting
`input.files`, so `upload_file` works and isn't limited to the drop path.

**Validation.** 4 new Swift tests (MIME inference and override, missing path,
directory, empty input, caps) and 5 new Node tests (assignment, event order,
wrapper resolution, bad target, drop sequence); full suites pass at 13 and 10.

Checked against real Safari with a signed build and a fixture page: single
upload, multi-file upload, `mimeType` override with `waitForText`, and a two-file
drop all landed with the right names, types, and sizes. An 8 MB file crossed the
bridge intact in ~290 ms. Missing path, directory, oversize, no path, wrong
target, and two files into a single-file input each returned `isError` with
usable text.

Also ran `node --check` on the changed scripts, `swift build -c release`, the
signed `xcodebuild`, and `git diff --check`.
