### PR TITLE
fix: keep element text and accessible names in snapshot and find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 ### Bug Fixes
+- Fixed `snapshot` dropping an element's own text when that element also has element children, so mixed content such as `<button><span>9</span>All</button>` no longer loses `All`.
+- Fixed `find` missing elements named only by `aria-label` or another accessible-name source; `text` now matches the accessible name as well as visible text.
+- `find` without `selector`, `text`, or `role` now returns `invalid_input` instead of an empty result that looks like a failed match.
 - Fixed `snapshot` crashing on SVG elements with non-string `type` properties.
 - Retried trace startup once after an interceptor timeout so a transient `start_trace interceptor did not respond` failure no longer aborts the traced action.
 

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -201,9 +201,14 @@
             if (childNode) children.push(childNode);
         }
 
-        // For text-only leaf nodes, include text content
-        if (children.length === 0 && element.textContent) {
-            const text = element.textContent.trim();
+        // Leaf nodes report their whole text content. Nodes that also have
+        // element children report their own direct text nodes, so mixed
+        // content such as <button><span>9</span>All</button> keeps "All".
+        const rawText = children.length === 0
+            ? element.textContent
+            : ownTextContent(element);
+        if (rawText) {
+            const text = rawText.trim();
             if (text && text.length <= 500) {
                 node.text = text;
             } else if (text) {
@@ -214,6 +219,15 @@
         if (children.length > 0) node.children = children;
 
         return node;
+    }
+
+    // Text of an element's direct text-node children only, in document order.
+    function ownTextContent(element) {
+        let text = "";
+        for (const child of element.childNodes) {
+            if (child.nodeType === Node.TEXT_NODE) text += child.textContent;
+        }
+        return text;
     }
 
     function isVisible(element) {
@@ -321,6 +335,15 @@
     // ─── Element Finding ─────────────────────────────────────────────
 
     function findElements(params) {
+        if (!params.selector && !params.text && !params.role) {
+            throw toolError(
+                "invalid_input",
+                "find requires selector, text, or role",
+                false,
+                "fix_input"
+            );
+        }
+
         const results = [];
 
         if (params.selector) {
@@ -331,16 +354,18 @@
         }
 
         if (params.text) {
+            const needle = params.text.toLowerCase();
+            // Also match the accessible name, so an icon button labelled only
+            // by aria-label is reachable by the name snapshots report for it.
+            const matches = (node) =>
+                node.textContent?.toLowerCase().includes(needle) ||
+                getAccessibleName(node)?.toLowerCase().includes(needle);
             const walker = document.createTreeWalker(
                 document.body,
                 NodeFilter.SHOW_ELEMENT,
                 {
                     acceptNode: (node) =>
-                        node.textContent &&
-                        node.textContent
-                            .toLowerCase()
-                            .includes(params.text.toLowerCase()) &&
-                        isVisible(node)
+                        matches(node) && isVisible(node)
                             ? NodeFilter.FILTER_ACCEPT
                             : NodeFilter.FILTER_SKIP,
                 }

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -200,7 +200,7 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "find",
-                description: "Find elements by selector, text, or ARIA role. Returns UIDs.",
+                description: "Find elements by selector, visible text or accessible name, or ARIA role. Returns UIDs.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 |------|-------------|
 | `read_page` | Get page content as `text`, `html`, or `snapshot` |
 | `snapshot` | Accessibility tree with element UIDs for interaction |
-| `find` | Find elements by CSS selector, text, or ARIA role |
+| `find` | Find elements by CSS selector, visible text or accessible name, or ARIA role |
 
 ### Interaction
 

--- a/Tests/content-element-text.test.mjs
+++ b/Tests/content-element-text.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+// Minimal DOM stand-ins: enough for snapshot tree building and find(), which
+// only need node types, children, text, attributes, and visibility.
+function text(value) {
+    return { nodeType: TEXT_NODE, textContent: value };
+}
+
+function el(tag, options = {}, children = []) {
+    const node = {
+        nodeType: ELEMENT_NODE,
+        tagName: tag.toUpperCase(),
+        attributes: options.attributes || {},
+        hidden: false,
+        id: options.id || "",
+        childNodes: children,
+        getAttribute(name) {
+            return name in this.attributes ? this.attributes[name] : null;
+        },
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 10, height: 10 }),
+    };
+    Object.defineProperty(node, "children", {
+        get: () => node.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    Object.defineProperty(node, "textContent", {
+        get: () => node.childNodes.map((c) => c.textContent).join(""),
+    });
+    return node;
+}
+
+function loadContent(body) {
+    let runtimeListener;
+
+    const document = {
+        body,
+        documentElement: body,
+        getElementById: () => null,
+        querySelector: () => null,
+        createTreeWalker(root, _whatToShow, filter) {
+            const queue = [];
+            const collect = (node) => {
+                for (const child of node.children) {
+                    queue.push(child);
+                    collect(child);
+                }
+            };
+            collect(root);
+            return {
+                nextNode() {
+                    while (queue.length) {
+                        const node = queue.shift();
+                        if (filter.acceptNode(node) === 1) return node;
+                    }
+                    return null;
+                },
+            };
+        },
+    };
+
+    vm.runInNewContext(source, {
+        browser: {
+            runtime: {
+                onMessage: { addListener: (fn) => { runtimeListener = fn; } },
+            },
+        },
+        document,
+        Node: { ELEMENT_NODE, TEXT_NODE },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            postMessage: () => {},
+            getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+        },
+    });
+
+    return (action, params) => new Promise((resolve) => {
+        runtimeListener({ action, params }, {}, resolve);
+    });
+}
+
+test("snapshot keeps an element's own text when it also has element children", async () => {
+    const call = loadContent(
+        el("body", {}, [
+            el("h2", {}, [text("Trash"), el("span", {}, [text(".")])]),
+            el("button", {}, [el("span", {}, [text("9")]), text("All")]),
+        ])
+    );
+
+    const { data } = await call("snapshot", {});
+    const [heading, button] = data.children;
+
+    assert.equal(heading.text, "Trash");
+    assert.equal(heading.children[0].text, ".");
+    assert.equal(button.text, "All");
+    assert.equal(button.children[0].text, "9");
+});
+
+test("snapshot still reports full text for leaf elements", async () => {
+    const call = loadContent(el("body", {}, [el("p", {}, [text("only text")])]));
+
+    const { data } = await call("snapshot", {});
+
+    assert.equal(data.children[0].text, "only text");
+});
+
+test("find matches an accessible name that is not visible text", async () => {
+    const call = loadContent(
+        el("body", {}, [
+            el("button", { attributes: { "aria-label": "Open Trash" }, id: "icon" }, [
+                text("🗑"),
+            ]),
+        ])
+    );
+
+    const { data } = await call("find", { text: "Open Trash" });
+
+    assert.equal(data.length, 1);
+    assert.equal(data[0].id, "icon");
+    assert.equal(data[0].name, "Open Trash");
+});
+
+test("find still matches visible text", async () => {
+    const call = loadContent(
+        el("body", {}, [el("button", { id: "restore" }, [text("Restore")])])
+    );
+
+    const { data } = await call("find", { text: "restore" });
+
+    assert.equal(data.length, 1);
+    assert.equal(data[0].id, "restore");
+});
+
+test("find rejects a call with no target argument", async () => {
+    const call = loadContent(el("body", {}, []));
+
+    const response = await call("find", { query: "Restore" });
+
+    assert.equal(response.data, null);
+    assert.equal(response.errorCode, "invalid_input");
+    assert.equal(response.recoveryAction, "fix_input");
+    assert.match(response.error, /selector, text, or role/);
+});


### PR DESCRIPTION
## Problem

`snapshot` drops an element's own text when that element also has element children. `<button><span>9</span>All</button>` comes back with only `9`, and `<h2>Trash<span>.</span></h2>` comes back with no heading text at all, so a tab strip with counts reads as a list of bare numerals.

`find({text})` looks at visible text only, so a button labelled `aria-label="Open Trash"` can't be found by the name `snapshot` reports for it.

`find` with no recognised argument returns `[]`, which reads as "nothing matched" rather than "wrong argument".

## Root cause

`buildTree` guards text extraction with `children.length === 0`, so mixed content contributes nothing. `findElements` filters its TreeWalker on `node.textContent` alone and validates nothing first.

## Fix

Leaf nodes keep their full text content; elements with element children now report their own direct text nodes. `find({text})` falls back to `getAccessibleName` — the same name snapshots already expose. `find` without `selector`, `text`, or `role` returns the existing `invalid_input` / `fix_input` error.

## Validation

`node --test Tests/*.mjs` (20 tests, 5 new), `swift test` (11 tests), `swift build -c release`, signed Debug `xcodebuild`, `node --check` on the extension scripts.

Real Safari on a signed build of this branch, fresh tab, localhost fixture: the two snapshot cases above now report `Trash` and `All`, leaf output is unchanged, `find({text: "Open Trash"})` returns the icon button that previously returned `[]`, `find({text: "Restore"})` is unchanged, and `find({})` errors.

Checked on a real app page with 5,590 elements: the accessible-name fallback adds 7 ms across the whole document, and only 6 elements carry mixed-content text totalling 59 bytes, so snapshot size is effectively unchanged.
