### PR TITLE
feat: report viewport, scale, visibility, and focus with screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `press_key`, `click`, `hover`, `scroll`, `drag`, `select_option`, and `form_input` now return `invalid_input` for missing or empty required arguments instead of a raw JavaScript error.
 - `getAccessibleName` now escapes element ids before building a `label[for=...]` selector, so an id containing a quote no longer fails the whole page's snapshot, and resolves every id in an `aria-labelledby` list rather than only the first.
 - `press_key` now reports `Digit1`-style codes for digits instead of `Key1`, and `scroll` treats `amount: 0` as an explicit distance rather than falling back to the viewport height.
+- `screenshot` now returns `internal_error` when Safari hands back an empty or non-PNG payload, instead of emitting it as base64 image content and leaving the client to reject the whole result as malformed.
 - Fixed `snapshot` dropping an element's own text when that element also has element children, so mixed content such as `<button><span>9</span>All</button>` no longer loses `All`.
 - Fixed `find` missing elements named only by `aria-label` or another accessible-name source; `text` now matches the accessible name as well as visible text.
 - `find` without `selector`, `text`, or `role` now returns `invalid_input` instead of an empty result that looks like a failed match.
@@ -35,6 +36,7 @@
 - `type_text` now supports opt-in native macOS keyboard events for contenteditable and framework-managed editors.
 - Added `upload_file` and `drop_file` for attaching explicit local files to a file input or dropping them onto an element.
 - Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
+- `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
 
 ### Bug Fixes
 - Stop stale per-port token files from causing endless extension reconnect attempts and popup state cycling.

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -591,11 +591,43 @@ async function handleScreenshot(params) {
         await delay(300);
     }
 
+    // Context before the frame: a page that loses focus between the two reads
+    // then produces a warning about a good frame rather than an all-clear on a
+    // stale one.
+    const context = await capturePageContext(tabId);
     const dataUrl = await browser.tabs.captureVisibleTab(tab.windowId, {
         format: "png",
     });
-    // Strip data URI prefix, return raw base64
-    return dataUrl.replace(/^data:image\/\w+;base64,/, "");
+
+    return {
+        // Raw base64, data URI prefix stripped
+        image: dataUrl.replace(/^data:image\/\w+;base64,/, ""),
+        ...context,
+    };
+}
+
+// Viewport, scale, visibility, and focus at capture time. Safari does not
+// repaint an occluded page, so a capture of a hidden page can predate the last
+// action, and it does not match :focus while its window is not key.
+async function capturePageContext(tabId) {
+    try {
+        const results = await browser.scripting.executeScript({
+            target: { tabId },
+            func: () => ({
+                visible: document.visibilityState === "visible",
+                hasFocus: document.hasFocus(),
+                viewport: {
+                    width: window.innerWidth,
+                    height: window.innerHeight,
+                },
+                devicePixelRatio: window.devicePixelRatio,
+            }),
+        });
+        return results[0]?.result || {};
+    } catch (err) {
+        console.warn("[MCPSafari] Screenshot context unavailable:", err);
+        return {};
+    }
 }
 
 // ─── JavaScript Execution Handler ────────────────────────────────────

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -1076,12 +1076,105 @@ actor SafariMCPServer {
         if let tabId = args["tabId"]?.intValue { params["tabId"] = AnyCodable(tabId) }
         let response = try await bridge.send(action: "screenshot", params: params)
 
-        if response.success, let imageData = response.data?.stringValue {
-            return CallTool.Result(content: [
-                Self.imageContent(data: imageData, mimeType: "image/png"),
-            ])
+        guard response.success, let raw = response.data?.stringValue else {
+            return textResult(response)
         }
-        return textResult(response)
+
+        // Current extensions send the image plus its capture context; older
+        // ones send the base64 image on its own.
+        let capture = Self.decodeCapture(raw)
+        let imageData = capture?["image"]?.stringValue ?? raw
+
+        if let failure = Self.captureFailure(imageData) {
+            return Self.failureResult(failure)
+        }
+
+        var content: [Tool.Content] = [
+            Self.imageContent(data: imageData, mimeType: "image/png"),
+        ]
+        if let capture, let note = Self.captureNote(capture) {
+            content.append(Self.textContent(note))
+        }
+        return CallTool.Result(content: content)
+    }
+
+    /// Safari resolves a failed capture to an empty or non-image payload, and
+    /// the extension forwards whatever it gets. Emitting that as base64 image
+    /// content makes the whole tool result unparseable for the client, which
+    /// reads as "this tool is broken" rather than as a recoverable failure.
+    static func captureFailure(_ image: String) -> ToolFailure? {
+        // Every extension version asks captureVisibleTab for PNG, so anything
+        // without the signature is a failed capture rather than another format.
+        let bytes = Data(base64Encoded: image)
+        if let bytes, bytes.starts(with: [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]) {
+            return nil
+        }
+
+        // debugDescription quotes and escapes the prefix, so an HTML or data-URL
+        // payload cannot break the error message across lines.
+        let head = String(image.prefix(48)).debugDescription
+        let payload: String
+        if image.isEmpty {
+            payload = "an empty payload"
+        } else if bytes == nil {
+            payload = "\(image.utf8.count) bytes that are not base64: \(head)"
+        } else {
+            payload = "\(image.utf8.count) base64 bytes with no PNG signature: \(head)"
+        }
+        return ToolFailure(
+            code: "internal_error",
+            message: "Safari returned \(payload) instead of PNG image data. "
+                + "Re-enable the MCPSafari extension for this page in Safari Settings > "
+                + "Extensions, or relaunch Safari, then retry.",
+            retryable: false,
+            recoveryAction: "inspect_error"
+        )
+    }
+
+    /// The extension serializes non-string tool data, so a capture arrives as
+    /// JSON text. Base64 image data never parses as JSON.
+    static func decodeCapture(_ raw: String) -> [String: AnyCodable]? {
+        guard raw.hasPrefix("{"), let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([String: AnyCodable].self, from: data)
+    }
+
+    /// Describes the captured frame: pixel space, and what state Safari withheld
+    /// from a page it was not presenting when the capture was taken.
+    static func captureNote(_ capture: [String: AnyCodable]) -> String? {
+        var parts: [String] = []
+        if let viewport = capture["viewport"]?.objectValue,
+           let width = number(viewport["width"]),
+           let height = number(viewport["height"]) {
+            let scale = number(capture["devicePixelRatio"]) ?? 1
+            parts.append(
+                "Viewport \(Int(width))x\(Int(height)) CSS px, devicePixelRatio \(formatScale(scale)). "
+                + "The PNG is in device pixels; click(x, y) takes CSS pixels."
+            )
+        }
+        if capture["visible"]?.boolValue == false {
+            // A hidden page is also unfocused, so the focus note would add noise.
+            parts.append(
+                "Page visibility: hidden. Safari does not repaint an occluded page or run its "
+                + "requestAnimationFrame callbacks, so this frame may predate your last action "
+                + "and any rAF-scheduled work has not run."
+            )
+        } else if capture["hasFocus"]?.boolValue == false {
+            parts.append(
+                "Window not focused. Safari does not match :focus or :focus-within while its "
+                + "window is not key, so focus states are missing from this frame even though "
+                + "document.activeElement is set."
+            )
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " ")
+    }
+
+    /// JSON numbers arrive as Int or Double depending on the value.
+    private static func number(_ value: AnyCodable?) -> Double? {
+        value?.doubleValue ?? value?.intValue.map(Double.init)
+    }
+
+    private static func formatScale(_ scale: Double) -> String {
+        scale == scale.rounded() ? String(Int(scale)) : String(scale)
     }
 
     private func handleJavaScript(_ args: [String: Value]) async throws -> CallTool.Result {

--- a/MCPServer/Tests/MCPSafariTests/ScreenshotContextTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/ScreenshotContextTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import MCPSafari
+
+struct ScreenshotContextTests {
+    @Test func captureNoteReportsPixelSpaceForIntegerAndFractionalScales() throws {
+        let integerScale = SafariMCPServer.captureNote([
+            "viewport": AnyCodable(["width": AnyCodable(1200), "height": AnyCodable(828)]),
+            "devicePixelRatio": AnyCodable(2),
+            "visible": AnyCodable(true),
+        ])
+        #expect(integerScale == """
+        Viewport 1200x828 CSS px, devicePixelRatio 2. \
+        The PNG is in device pixels; click(x, y) takes CSS pixels.
+        """)
+
+        let fractionalScale = SafariMCPServer.captureNote([
+            "viewport": AnyCodable(["width": AnyCodable(800), "height": AnyCodable(600)]),
+            "devicePixelRatio": AnyCodable(1.5),
+            "visible": AnyCodable(true),
+        ])
+        #expect(fractionalScale?.contains("devicePixelRatio 1.5") == true)
+    }
+
+    @Test func captureNoteWarnsWhenThePageWasHidden() throws {
+        let note = SafariMCPServer.captureNote([
+            "viewport": AnyCodable(["width": AnyCodable(1200), "height": AnyCodable(828)]),
+            "devicePixelRatio": AnyCodable(2),
+            "visible": AnyCodable(false),
+            "hasFocus": AnyCodable(false),
+        ])
+        #expect(note?.contains("Page visibility: hidden") == true)
+        #expect(note?.contains("may predate your last action") == true)
+        #expect(note?.contains("requestAnimationFrame") == true)
+        // A hidden page is unfocused by definition; one warning is enough.
+        #expect(note?.contains("Window not focused") == false)
+    }
+
+    @Test func captureNoteWarnsWhenTheWindowWasNotKey() throws {
+        let note = SafariMCPServer.captureNote([
+            "viewport": AnyCodable(["width": AnyCodable(1200), "height": AnyCodable(828)]),
+            "devicePixelRatio": AnyCodable(2),
+            "visible": AnyCodable(true),
+            "hasFocus": AnyCodable(false),
+        ])
+        #expect(note?.contains("Window not focused") == true)
+        #expect(note?.contains(":focus-within") == true)
+        #expect(note?.contains("Page visibility: hidden") == false)
+    }
+
+    @Test func captureNoteStaysQuietForAVisibleFocusedPage() throws {
+        let note = SafariMCPServer.captureNote([
+            "viewport": AnyCodable(["width": AnyCodable(1200), "height": AnyCodable(828)]),
+            "devicePixelRatio": AnyCodable(2),
+            "visible": AnyCodable(true),
+            "hasFocus": AnyCodable(true),
+        ])
+        #expect(note?.contains("Viewport 1200x828") == true)
+        #expect(note?.contains("not focused") == false)
+        #expect(note?.contains("hidden") == false)
+    }
+
+    @Test func captureNoteIsOmittedWhenThePageContextIsUnavailable() throws {
+        #expect(SafariMCPServer.captureNote([:]) == nil)
+    }
+
+    @Test func captureDecodingSeparatesSerializedCapturesFromLegacyImages() throws {
+        let capture = SafariMCPServer.decodeCapture(
+            #"{"image":"AAAB","visible":false,"viewport":{"width":1200,"height":828},"devicePixelRatio":2}"#
+        )
+        #expect(capture?["image"]?.stringValue == "AAAB")
+        #expect(SafariMCPServer.captureNote(capture ?? [:])?.contains("hidden") == true)
+
+        // A base64 PNG from an older extension is not JSON.
+        #expect(SafariMCPServer.decodeCapture("iVBORw0KGgoAAAANSUhEUg==") == nil)
+    }
+
+    @Test func captureFailureAcceptsDecodableImageData() throws {
+        #expect(SafariMCPServer.captureFailure("iVBORw0KGgoAAAANSUhEUg==") == nil)
+    }
+
+    @Test func captureFailureRejectsAnEmptyImageInsideAValidCapture() throws {
+        // Path A of issue #38: the capture object decodes and `image` is a
+        // non-nil empty string, so a stringValue check alone lets it through.
+        let capture = SafariMCPServer.decodeCapture(
+            #"{"image":"","visible":true,"viewport":{"width":1200,"height":828},"devicePixelRatio":2}"#
+        )
+        let failure = try #require(
+            SafariMCPServer.captureFailure(capture?["image"]?.stringValue ?? "")
+        )
+        #expect(failure.code == "internal_error")
+        #expect(failure.retryable == false)
+        #expect(failure.message.contains("an empty payload"))
+    }
+
+    // Path B of issue #38 and its neighbours: a payload that is not JSON reaches
+    // the legacy branch, which used to forward it verbatim as base64. Foundation
+    // decodes "====" to one garbage byte, and a truncated capture decodes
+    // cleanly too, so base64 validity alone is not enough.
+    @Test(arguments: [
+        ("data:text/html;base64,PGh0bWw+", "not base64"),
+        ("<!DOCTYPE html>\n<html>\n", "not base64"),
+        ("====", "no PNG signature"),
+    ])
+    func captureFailureRejectsPayloadsThatAreNotPNGImages(
+        payload: String,
+        expected: String
+    ) throws {
+        let failure = try #require(SafariMCPServer.captureFailure(payload))
+        #expect(failure.code == "internal_error")
+        #expect(failure.message.contains(expected))
+        // The first bytes tell a caller which payload Safari sent, on one line.
+        #expect(failure.message.contains(payload.prefix(12)))
+        #expect(failure.message.contains("\n") == false)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 
 | Tool | Description |
 |------|-------------|
-| `screenshot` | Capture the visible tab area as a PNG image |
+| `screenshot` | Capture the visible tab area as a PNG image, with viewport, scale, page visibility, and window focus |
 
 ### JavaScript
 

--- a/Tests/screenshot-context.test.mjs
+++ b/Tests/screenshot-context.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/background.js", import.meta.url),
+    "utf8"
+);
+
+const DATA_URL = "data:image/png;base64,AAAB";
+
+// Background harness with just enough browser API for handleScreenshot. `page`
+// stands in for the globals the injected context function reads.
+function loadBackground({ executeScript, page = {}, captureVisibleTab }) {
+    const browser = {
+        alarms: { create() {}, onAlarm: { addListener() {} } },
+        runtime: {
+            getManifest: () => ({ version: "9.9.9" }),
+            onMessage: { addListener() {} },
+            sendNativeMessage: async () => ({ tokens: {} }),
+        },
+        scripting: { executeScript },
+        storage: {
+            local: { get: async () => ({}), set() {} },
+            session: { get: async () => ({}), set() {}, remove: async () => {} },
+        },
+        tabs: {
+            get: async (id) => ({ id, active: true, windowId: 1 }),
+            captureVisibleTab: captureVisibleTab ?? (async () => DATA_URL),
+            onUpdated: { addListener() {}, removeListener() {} },
+            update: async () => {},
+        },
+    };
+
+    const context = vm.createContext({
+        browser,
+        clearTimeout() {},
+        console: { error() {}, log() {}, warn() {} },
+        Date,
+        document: {
+            visibilityState: page.visibilityState ?? "visible",
+            hasFocus: () => page.hasFocus ?? true,
+        },
+        Promise,
+        setTimeout: () => {},
+        WebSocket: class { send() {} },
+        window: {
+            innerWidth: page.innerWidth ?? 1200,
+            innerHeight: page.innerHeight ?? 828,
+            devicePixelRatio: page.devicePixelRatio ?? 2,
+        },
+    });
+    vm.runInContext(source, context);
+
+    return (expression) => vm.runInContext(expression, context);
+}
+
+test("screenshot reports viewport, scale, visibility, and focus with the image", async () => {
+    const evaluate = loadBackground({
+        executeScript: async () => [{
+            result: {
+                visible: false,
+                hasFocus: false,
+                viewport: { width: 1200, height: 828 },
+                devicePixelRatio: 2,
+            },
+        }],
+    });
+
+    const capture = await evaluate("handleScreenshot({ tabId: 1 })");
+
+    assert.equal(capture.image, "AAAB");
+    assert.equal(capture.visible, false);
+    assert.equal(capture.hasFocus, false);
+    assert.deepEqual(capture.viewport, { width: 1200, height: 828 });
+    assert.equal(capture.devicePixelRatio, 2);
+});
+
+test("the injected context function reads visibility, focus, and viewport from the page", async () => {
+    const evaluate = loadBackground({
+        // Run the real injected function instead of stubbing its result.
+        executeScript: async ({ func }) => [{ result: func() }],
+        page: {
+            visibilityState: "hidden",
+            hasFocus: false,
+            innerWidth: 900,
+            innerHeight: 600,
+            devicePixelRatio: 1,
+        },
+    });
+
+    const capture = await evaluate("handleScreenshot({ tabId: 1 })");
+
+    assert.equal(capture.visible, false);
+    assert.equal(capture.hasFocus, false);
+    // Field-wise: the viewport object comes from the VM realm, so a deep
+    // comparison against a plain object fails on the prototype alone.
+    assert.equal(capture.viewport.width, 900);
+    assert.equal(capture.viewport.height, 600);
+    assert.equal(capture.devicePixelRatio, 1);
+});
+
+test("page context is read before the frame, not after it", async () => {
+    const order = [];
+    const evaluate = loadBackground({
+        executeScript: async () => {
+            order.push("context");
+            return [{ result: { visible: true, hasFocus: true } }];
+        },
+        captureVisibleTab: async () => {
+            order.push("capture");
+            return DATA_URL;
+        },
+    });
+
+    await evaluate("handleScreenshot({ tabId: 1 })");
+
+    // Reading state after the frame can report a page as focused when it lost
+    // focus during the capture, which is a false all-clear.
+    assert.deepEqual(order, ["context", "capture"]);
+});
+
+test("screenshot still returns the image when page context is unavailable", async () => {
+    const evaluate = loadBackground({
+        executeScript: async () => { throw new Error("cannot access page"); },
+    });
+
+    const capture = await evaluate("handleScreenshot({ tabId: 1 })");
+
+    assert.equal(capture.image, "AAAB");
+    assert.deepEqual(Object.keys(capture), ["image"]);
+});


### PR DESCRIPTION
## Problem

Screenshots said nothing about their own capture: device pixels versus CSS pixels (#35). Worse when a capture fails — Safari returns an empty or non-image payload and the extension forwards it, so labelling that base64 makes the whole result unparseable (#38).

## Fix

Results now carry viewport, scale, visibility, and focus, condensed into one note (hidden: no repaint, no `requestAnimationFrame`, so the frame may predate your last action; visible but not key: no `:focus`). Both paths validate before emitting — empty, invalid base64, or no PNG signature returns `internal_error`, never an image. Bare-base64 extensions unchanged.

## Validation

46 Node tests (4 new), 31 Swift (9 new), release build, signed `xcodebuild`, `node --check`.

Signed build over MCP stdio, four window states: correct note each time, valid PNGs throughout. Released 0.2.9 extension with this server: one image, no note. Failure path is unit-tested only — live Safari will not fail a capture on demand.
