### PR TITLE
fix: stop leaking secrets in snapshots and reporting silent no-ops as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
 # Changelog
 
 ## [Unreleased]
+### Security
+- `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
+
 ### Bug Fixes
+- `select_option` now fails with `target_not_found` instead of reporting success when the requested value matches no option, and restores the previous selection.
+- `form_input` now fails with `target_not_found` when no field matched, instead of returning a successful result whose body reads `not found`.
+- `read_console` with `clear` now removes only the messages the call returned, so a level- or pattern-filtered read no longer discards unread messages.
+- `find` by CSS selector is now capped at 50 matches, the same cap the text and role strategies already used.
+- `press_key`, `click`, `hover`, `scroll`, `drag`, `select_option`, and `form_input` now return `invalid_input` for missing or empty required arguments instead of a raw JavaScript error.
+- `getAccessibleName` now escapes element ids before building a `label[for=...]` selector, so an id containing a quote no longer fails the whole page's snapshot, and resolves every id in an `aria-labelledby` list rather than only the first.
+- `press_key` now reports `Digit1`-style codes for digits instead of `Key1`, and `scroll` treats `amount: 0` as an explicit distance rather than falling back to the viewport height.
 - Fixed `snapshot` dropping an element's own text when that element also has element children, so mixed content such as `<button><span>9</span>All</button>` no longer loses `All`.
 - Fixed `find` missing elements named only by `aria-label` or another accessible-name source; `text` now matches the accessible name as well as visible text.
 - `find` without `selector`, `text`, or `role` now returns `invalid_input` instead of an empty result that looks like a failed match.

--- a/MCPSafari/MCPSafari Extension/Resources/console-interceptor.js
+++ b/MCPSafari/MCPSafari Extension/Resources/console-interceptor.js
@@ -95,15 +95,13 @@
         }
 
         if (params.clear) {
-            // Only clear the messages that matched the filter, not the entire buffer
-            if (params.level && params.level !== "all") {
-                for (let i = messages.length - 1; i >= 0; i--) {
-                    if (messages[i].level === params.level) {
-                        messages.splice(i, 1);
-                    }
+            // Clear exactly what this call returned, so a level- or pattern-filtered
+            // read never discards messages the caller never saw.
+            const returned = new Set(filtered);
+            for (let i = messages.length - 1; i >= 0; i--) {
+                if (returned.has(messages[i])) {
+                    messages.splice(i, 1);
                 }
-            } else {
-                messages.length = 0;
             }
         }
 

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -24,6 +24,14 @@
         return error;
     }
 
+    // Escapes a value for use inside a quoted CSS attribute selector.
+    function escapeCssString(value) {
+        if (window.CSS && typeof window.CSS.escape === "function") {
+            return window.CSS.escape(value);
+        }
+        return String(value).replace(/["\\]/g, "\\$&");
+    }
+
     function getUid(element) {
         if (uidMap.has(element)) return uidMap.get(element);
         const uid = `e${++uidCounter}`;
@@ -180,9 +188,10 @@
 
         if (name) node.name = name;
 
-        // Value for inputs
+        // Value for inputs. Secrets report their presence, not their contents,
+        // so a snapshot of a filled login or payment form is safe to hand to a model.
         if (element.value !== undefined && element.value !== "") {
-            node.value = String(element.value);
+            node.value = isSensitiveInput(element) ? REDACTED : String(element.value);
         }
 
         // States
@@ -286,6 +295,33 @@
         return implicitRoles[tag] || null;
     }
 
+    // Inputs whose contents must never reach a snapshot. Covers the explicit
+    // password type plus the autocomplete tokens browsers use for secrets.
+    const REDACTED = "[redacted]";
+    const SENSITIVE_AUTOCOMPLETE = new Set([
+        "current-password",
+        "new-password",
+        "one-time-code",
+        "cc-number",
+        "cc-csc",
+        "cc-exp",
+        "cc-exp-month",
+        "cc-exp-year",
+    ]);
+
+    function isSensitiveInput(element) {
+        const tag = element.tagName ? element.tagName.toLowerCase() : "";
+        if (tag !== "input") return false;
+        if ((element.type || "").toLowerCase() === "password") return true;
+
+        const autocomplete = element.getAttribute("autocomplete");
+        if (!autocomplete) return false;
+        return autocomplete
+            .toLowerCase()
+            .split(/\s+/)
+            .some((token) => SENSITIVE_AUTOCOMPLETE.has(token));
+    }
+
     function getInputRole(element) {
         const type = (element.type || "text").toLowerCase();
         const inputRoles = {
@@ -311,16 +347,29 @@
         const ariaLabel = element.getAttribute("aria-label");
         if (ariaLabel) return ariaLabel;
 
-        // aria-labelledby
+        // aria-labelledby takes a space-separated list of ids, joined in order.
         const labelledBy = element.getAttribute("aria-labelledby");
         if (labelledBy) {
-            const labelEl = document.getElementById(labelledBy);
-            if (labelEl) return labelEl.textContent.trim();
+            const labelText = labelledBy
+                .split(/\s+/)
+                .filter(Boolean)
+                .map((id) => document.getElementById(id))
+                .filter(Boolean)
+                .map((labelEl) => labelEl.textContent.trim())
+                .filter(Boolean)
+                .join(" ");
+            if (labelText) return labelText;
         }
 
-        // Label element for inputs
+        // Label element for inputs. `labels` covers labelable controls directly;
+        // the selector fallback must escape the id, because a raw id containing
+        // a quote builds a malformed selector that throws and fails the snapshot.
+        if (element.labels && element.labels.length > 0) {
+            const labelText = element.labels[0].textContent.trim();
+            if (labelText) return labelText;
+        }
         if (element.id) {
-            const label = document.querySelector(`label[for="${element.id}"]`);
+            const label = document.querySelector(`label[for="${escapeCssString(element.id)}"]`);
             if (label) return label.textContent.trim();
         }
 
@@ -338,6 +387,10 @@
 
     // ─── Element Finding ─────────────────────────────────────────────
 
+    // One cap for every match strategy, so a broad selector cannot return an
+    // unbounded result set and swamp the caller's context.
+    const MAX_FIND_RESULTS = 50;
+
     function findElements(params) {
         if (!params.selector && !params.text && !params.role) {
             throw toolError(
@@ -353,6 +406,7 @@
         if (params.selector) {
             const elements = document.querySelectorAll(params.selector);
             for (const el of elements) {
+                if (results.length >= MAX_FIND_RESULTS) break;
                 results.push(describeElement(el));
             }
         }
@@ -375,7 +429,7 @@
                 }
             );
             let node;
-            while ((node = walker.nextNode()) && results.length < 20) {
+            while ((node = walker.nextNode()) && results.length < MAX_FIND_RESULTS) {
                 // Only include leaf-ish elements (avoid returning <body> etc.)
                 if (
                     node.children.length === 0 ||
@@ -389,7 +443,7 @@
         if (params.role) {
             const allElements = document.querySelectorAll("*");
             for (const el of allElements) {
-                if (results.length >= 50) break;
+                if (results.length >= MAX_FIND_RESULTS) break;
                 if (getRole(el) === params.role && isVisible(el)) {
                     results.push(describeElement(el));
                 }
@@ -524,7 +578,14 @@
 
         // Click by selector or text
         const el = resolveElement(params);
-        if (!el) throw new Error("No element specified to click");
+        if (!el) {
+            throw toolError(
+                "invalid_input",
+                "click requires uid, selector, text, or x and y",
+                false,
+                "fix_input"
+            );
+        }
 
         simulateClick(el, params.doubleClick);
         const desc = el.tagName.toLowerCase();
@@ -679,18 +740,40 @@
     // ─── Form Input ──────────────────────────────────────────────────
 
     function formInput(params) {
-        const fields = params.fields || {};
-        const results = [];
+        const entries = Object.entries(params.fields || {});
+        if (entries.length === 0) {
+            throw toolError(
+                "invalid_input",
+                "form_input requires at least one CSS selector and value",
+                false,
+                "fix_input"
+            );
+        }
 
-        for (const [selector, value] of Object.entries(fields)) {
+        const results = [];
+        const missing = [];
+
+        for (const [selector, value] of entries) {
             const el = document.querySelector(selector);
             if (!el) {
+                missing.push(selector);
                 results.push(`${selector}: not found`);
                 continue;
             }
             el.focus();
             setInputValue(el, value, false);
             results.push(`${selector}: filled`);
+        }
+
+        // A partial fill still reports per-field results, but filling nothing is a
+        // failure rather than a success whose body happens to say "not found".
+        if (missing.length === entries.length) {
+            throw toolError(
+                "target_not_found",
+                `No form fields matched: ${missing.join(", ")}`,
+                false,
+                "take_snapshot"
+            );
         }
 
         return results.join("\n");
@@ -700,19 +783,57 @@
 
     function selectOption(params) {
         const el = resolveElement(params);
-        if (!el) throw new Error(`Select element not found`);
+        if (!el) {
+            throw toolError(
+                "invalid_input",
+                "select_option requires uid or selector",
+                false,
+                "fix_input"
+            );
+        }
         if (el.tagName.toLowerCase() !== "select") {
-            throw new Error(`Element is not a <select>: ${el.tagName}`);
+            throw toolError(
+                "target_not_found",
+                `Element is not a <select>: <${el.tagName.toLowerCase()}>`,
+                false,
+                "take_snapshot"
+            );
+        }
+        if (params.value === undefined && !params.label) {
+            throw toolError(
+                "invalid_input",
+                "select_option requires value or label",
+                false,
+                "fix_input"
+            );
         }
 
         if (params.value !== undefined) {
+            // Assigning an unmatched value clears the selection instead of
+            // throwing, so verify it took rather than reporting a silent no-op.
+            const previous = el.value;
             el.value = params.value;
-        } else if (params.label) {
+            if (el.value !== String(params.value)) {
+                el.value = previous;
+                throw toolError(
+                    "target_not_found",
+                    `No option with value "${params.value}" in <select>`,
+                    false,
+                    "take_snapshot"
+                );
+            }
+        } else {
             const option = Array.from(el.options).find(
                 (o) => o.textContent.trim() === params.label
             );
-            if (!option)
-                throw new Error(`Option with label "${params.label}" not found`);
+            if (!option) {
+                throw toolError(
+                    "target_not_found",
+                    `Option with label "${params.label}" not found`,
+                    false,
+                    "take_snapshot"
+                );
+            }
             el.value = option.value;
         }
 
@@ -730,7 +851,8 @@
             if (!target) throw new Error("Scroll target not found");
         }
 
-        const amount = params.amount || window.innerHeight * 0.8;
+        // Explicit null check: `amount: 0` is a caller-meant no-op, not "unset".
+        const amount = params.amount == null ? window.innerHeight * 0.8 : params.amount;
         const directionMap = {
             up: { top: -amount, left: 0 },
             down: { top: amount, left: 0 },
@@ -739,7 +861,14 @@
         };
 
         const scroll = directionMap[params.direction];
-        if (!scroll) throw new Error(`Invalid direction: ${params.direction}`);
+        if (!scroll) {
+            throw toolError(
+                "invalid_input",
+                `scroll requires direction up, down, left, or right; received ${params.direction}`,
+                false,
+                "fix_input"
+            );
+        }
 
         if (target === window) {
             window.scrollBy({ ...scroll, behavior: "smooth" });
@@ -752,15 +881,31 @@
 
     // ─── Press Key ───────────────────────────────────────────────────
 
+    // KeyboardEvent.code is physical-key based: letters are KeyX, digits Digit0-9.
+    function keyCode(key) {
+        if (key.length !== 1) return key;
+        if (key >= "0" && key <= "9") return `Digit${key}`;
+        if (/[a-z]/i.test(key)) return `Key${key.toUpperCase()}`;
+        return key;
+    }
+
     function pressKey(params) {
         const keyString = params.key;
+        if (typeof keyString !== "string" || keyString === "") {
+            throw toolError(
+                "invalid_input",
+                "press_key requires a non-empty key such as Enter, Tab, or Meta+a",
+                false,
+                "fix_input"
+            );
+        }
         const parts = keyString.split("+");
         const key = parts.pop();
         const modifiers = parts.map((m) => m.toLowerCase());
 
         const eventOpts = {
             key,
-            code: key.length === 1 ? `Key${key.toUpperCase()}` : key,
+            code: keyCode(key),
             bubbles: true,
             cancelable: true,
             ctrlKey: modifiers.includes("control") || modifiers.includes("ctrl"),
@@ -781,7 +926,14 @@
 
     function hoverElement(params) {
         const el = resolveElement(params);
-        if (!el) throw new Error("No element specified to hover");
+        if (!el) {
+            throw toolError(
+                "invalid_input",
+                "hover requires uid, selector, or text",
+                false,
+                "fix_input"
+            );
+        }
 
         el.scrollIntoView({ behavior: "instant", block: "center" });
 
@@ -813,8 +965,14 @@
             selector: params.toSelector,
         });
 
-        if (!fromEl) throw new Error("No source element specified for drag");
-        if (!toEl) throw new Error("No target element specified for drag");
+        if (!fromEl || !toEl) {
+            throw toolError(
+                "invalid_input",
+                "drag requires fromUid or fromSelector, and toUid or toSelector",
+                false,
+                "fix_input"
+            );
+        }
 
         fromEl.scrollIntoView({ behavior: "instant", block: "center" });
         const fromRect = fromEl.getBoundingClientRect();

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -208,7 +208,7 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "find",
-                description: "Find elements by selector, visible text or accessible name, or ARIA role. Returns UIDs.",
+                description: "Find elements by selector, visible text or accessible name, or ARIA role. Returns up to 50 UIDs.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 |------|-------------|
 | `read_page` | Get page content as `text`, `html`, or `snapshot` |
 | `snapshot` | Accessibility tree with element UIDs for interaction |
-| `find` | Find elements by CSS selector, visible text or accessible name, or ARIA role |
+| `find` | Find elements by CSS selector, visible text or accessible name, or ARIA role (up to 50 matches) |
 
 ### Interaction
 
@@ -412,6 +412,11 @@ The server generates a random UUID token at startup, writes it to `~/.config/mcp
 - Regex patterns capped at 200 characters and validated before forwarding
 - Wait durations capped at 300 seconds
 - File reads limited to explicit caller-provided paths, with directories rejected and 10 files / 10 MB capped per call
+- `find` returns at most 50 matches per call
+
+### Snapshot Redaction
+
+`snapshot` reports that a sensitive field has a value without reporting the value itself. Password inputs, and inputs whose `autocomplete` marks them as a password, one-time code, or payment card field, come back as `"value": "[redacted]"`. Everything else is reported verbatim, so a snapshot of a filled login or checkout form can be handed to a model without leaking the credential.
 
 ### Permissions
 

--- a/Tests/console-interceptor.test.mjs
+++ b/Tests/console-interceptor.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/console-interceptor.js", import.meta.url),
+    "utf8"
+);
+
+function loadInterceptor() {
+    const context = {
+        console: { log() {}, warn() {}, error() {}, info() {}, debug() {} },
+        window: { addEventListener() {}, postMessage() {} },
+        Date, JSON, RegExp, String, Set,
+    };
+    context.window.window = context.window;
+    vm.runInNewContext(source, context);
+    return context;
+}
+
+test("clearing a pattern-filtered read keeps messages the caller never saw", () => {
+    const { console: patched, window } = loadInterceptor();
+
+    patched.log("alpha keep-me");
+    patched.log("beta match-me");
+
+    const matched = window.__mcpGetConsoleMessages({ pattern: "match-me", clear: true });
+    const remaining = window.__mcpGetConsoleMessages({});
+
+    assert.deepEqual(Array.from(matched, (m) => m.text), ["beta match-me"]);
+    assert.deepEqual(Array.from(remaining, (m) => m.text), ["alpha keep-me"]);
+});
+
+test("clearing a level-filtered read leaves the other levels intact", () => {
+    const { console: patched, window } = loadInterceptor();
+
+    patched.log("a log line");
+    patched.error("an error line");
+
+    window.__mcpGetConsoleMessages({ level: "error", clear: true });
+    const remaining = window.__mcpGetConsoleMessages({});
+
+    assert.deepEqual(Array.from(remaining, (m) => m.text), ["a log line"]);
+});
+
+test("clearing an unfiltered read empties the buffer", () => {
+    const { console: patched, window } = loadInterceptor();
+
+    patched.log("one");
+    patched.warn("two");
+
+    window.__mcpGetConsoleMessages({ clear: true });
+
+    assert.deepEqual(Array.from(window.__mcpGetConsoleMessages({})), []);
+});
+
+test("level and pattern filters compose when clearing", () => {
+    const { console: patched, window } = loadInterceptor();
+
+    patched.error("fetch failed for /a");
+    patched.error("render failed");
+    patched.log("fetch started for /a");
+
+    const matched = window.__mcpGetConsoleMessages({ level: "error", pattern: "^fetch", clear: true });
+    const remaining = window.__mcpGetConsoleMessages({});
+
+    assert.deepEqual(Array.from(matched, (m) => m.text), ["fetch failed for /a"]);
+    assert.deepEqual(
+        Array.from(remaining, (m) => m.text),
+        ["render failed", "fetch started for /a"]
+    );
+});

--- a/Tests/content-tool-safety.test.mjs
+++ b/Tests/content-tool-safety.test.mjs
@@ -1,0 +1,312 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+// Minimal DOM stand-ins: enough for snapshot, find, and the interaction
+// handlers, which need node types, children, text, attributes, and visibility.
+function text(value) {
+    return { nodeType: TEXT_NODE, textContent: value };
+}
+
+function el(tag, options = {}, children = []) {
+    const node = {
+        nodeType: ELEMENT_NODE,
+        tagName: tag.toUpperCase(),
+        attributes: options.attributes || {},
+        hidden: false,
+        id: options.id || "",
+        childNodes: children,
+        getAttribute(name) {
+            return name in this.attributes ? this.attributes[name] : null;
+        },
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 10, height: 10 }),
+        scrollIntoView() {},
+        focus() {},
+        dispatchEvent() { return true; },
+        ...options.extra,
+    };
+    Object.defineProperty(node, "children", {
+        get: () => node.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    if (!("textContent" in (options.extra || {}))) {
+        Object.defineProperty(node, "textContent", {
+            get: () => node.childNodes.map((c) => c.textContent).join(""),
+        });
+    }
+    return node;
+}
+
+function loadContent(body, documentOverrides = {}) {
+    let listener;
+    const document = {
+        body,
+        documentElement: body,
+        activeElement: null,
+        getElementById: () => null,
+        querySelector: () => null,
+        querySelectorAll: () => [],
+        createTreeWalker(root, _show, filter) {
+            const queue = [];
+            const collect = (n) => { for (const c of n.children) { queue.push(c); collect(c); } };
+            collect(root);
+            return {
+                nextNode() {
+                    while (queue.length) {
+                        const n = queue.shift();
+                        if (filter.acceptNode(n) === 1) return n;
+                    }
+                    return null;
+                },
+            };
+        },
+        ...documentOverrides,
+    };
+
+    class FakeEvent {
+        constructor(type, options = {}) {
+            this.type = type;
+            Object.assign(this, options);
+        }
+    }
+
+    const scrolls = [];
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document,
+        Node: { ELEMENT_NODE, TEXT_NODE },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        Event: FakeEvent,
+        KeyboardEvent: FakeEvent,
+        MouseEvent: FakeEvent,
+        // No native `value` descriptor, so setInputValue takes its direct-assign path.
+        HTMLInputElement: class {},
+        HTMLTextAreaElement: class {},
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            postMessage: () => {},
+            innerHeight: 800,
+            scrollBy: (options) => scrolls.push(options),
+            getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+        },
+    });
+
+    const call = (action, params) => new Promise((r) => listener({ action, params }, {}, r));
+    call.scrolls = scrolls;
+    return call;
+}
+
+// ─── Snapshot redaction ──────────────────────────────────────────────
+
+test("snapshot redacts password field values but keeps ordinary ones", async () => {
+    const password = el("input", { id: "pw", extra: { type: "password", value: "hunter2" } });
+    const email = el("input", { id: "email", extra: { type: "email", value: "a@b.com" } });
+    const call = loadContent(el("body", {}, [password, email]));
+
+    const { data } = await call("snapshot", {});
+
+    assert.equal(data.children[0].value, "[redacted]");
+    assert.equal(data.children[1].value, "a@b.com");
+});
+
+test("snapshot redacts inputs marked sensitive by autocomplete", async () => {
+    const otp = el("input", {
+        attributes: { autocomplete: "one-time-code" },
+        extra: { type: "text", value: "123456" },
+    });
+    const card = el("input", {
+        attributes: { autocomplete: "section-payment cc-number" },
+        extra: { type: "text", value: "4111111111111111" },
+    });
+    const name = el("input", {
+        attributes: { autocomplete: "name" },
+        extra: { type: "text", value: "Jane" },
+    });
+    const call = loadContent(el("body", {}, [otp, card, name]));
+
+    const { data } = await call("snapshot", {});
+
+    assert.equal(data.children[0].value, "[redacted]");
+    assert.equal(data.children[1].value, "[redacted]");
+    assert.equal(data.children[2].value, "Jane");
+});
+
+// ─── Accessible name resolution ──────────────────────────────────────
+
+test("accessible name escapes ids that would build a malformed selector", async () => {
+    const selectors = [];
+    const target = el("div", { id: 'a"b' });
+    const call = loadContent(el("body", {}, [target]), {
+        querySelector: (selector) => {
+            // A real DOM throws on an unescaped quote; fail loudly the same way.
+            if (/[^\\]"[^\]]/.test(selector.slice('label[for="'.length))) {
+                throw new Error(`invalid selector: ${selector}`);
+            }
+            selectors.push(selector);
+            return null;
+        },
+    });
+
+    const { data, error } = await call("snapshot", {});
+
+    assert.equal(error, null);
+    assert.equal(data.children.length, 1);
+    assert.ok(selectors.length > 0, "the escaped selector was still queried");
+});
+
+test("aria-labelledby joins every referenced id", async () => {
+    const call = loadContent(
+        el("body", {}, [el("div", { attributes: { "aria-labelledby": "t1 t2" } })]),
+        {
+            getElementById: (id) => ({ textContent: id === "t1" ? "Delete" : "forever" }),
+        }
+    );
+
+    const { data } = await call("snapshot", {});
+
+    assert.equal(data.children[0].name, "Delete forever");
+});
+
+// ─── find caps ───────────────────────────────────────────────────────
+
+test("find by selector is capped like the other match strategies", async () => {
+    const many = Array.from({ length: 500 }, (_, i) => el("div", { id: `d${i}` }));
+    const call = loadContent(el("body", {}, many), { querySelectorAll: () => many });
+
+    const { data } = await call("find", { selector: "div" });
+
+    assert.equal(data.length, 50);
+});
+
+// ─── select_option ───────────────────────────────────────────────────
+
+function selectHarness(optionValues) {
+    const options = optionValues.map((value) => ({ value, textContent: value.toUpperCase() }));
+    let stored = optionValues[0];
+    const select = el("select", { id: "s" });
+    select.options = options;
+    // Mirrors the real setter: an unmatched value clears the selection.
+    Object.defineProperty(select, "value", {
+        get: () => stored,
+        set: (v) => { stored = options.some((o) => o.value === v) ? v : ""; },
+    });
+    return {
+        select,
+        current: () => stored,
+        call: loadContent(el("body", {}, [select]), { querySelector: () => select }),
+    };
+}
+
+test("select_option fails instead of silently selecting nothing", async () => {
+    const { call, current } = selectHarness(["a", "b"]);
+
+    const response = await call("select_option", { selector: "#s", value: "nope" });
+
+    assert.equal(response.errorCode, "target_not_found");
+    assert.match(response.error, /No option with value "nope"/);
+    assert.equal(current(), "a", "the previous selection is restored");
+});
+
+test("select_option still selects a real value and label", async () => {
+    const byValue = selectHarness(["a", "b"]);
+    const valueResponse = await byValue.call("select_option", { selector: "#s", value: "b" });
+    assert.equal(valueResponse.error, null);
+    assert.equal(byValue.current(), "b");
+
+    const byLabel = selectHarness(["a", "b"]);
+    const labelResponse = await byLabel.call("select_option", { selector: "#s", label: "B" });
+    assert.equal(labelResponse.error, null);
+    assert.equal(byLabel.current(), "b");
+});
+
+test("select_option requires a value or label", async () => {
+    const { call } = selectHarness(["a"]);
+
+    const response = await call("select_option", { selector: "#s" });
+
+    assert.equal(response.errorCode, "invalid_input");
+    assert.equal(response.recoveryAction, "fix_input");
+});
+
+// ─── form_input ──────────────────────────────────────────────────────
+
+test("form_input fails when no field matched, but reports a partial fill", async () => {
+    const field = el("input", { id: "a", extra: { value: "" } });
+    const allMissing = loadContent(el("body", {}, []), { querySelector: () => null });
+
+    const failed = await allMissing("form_input", { fields: { "#a": "1", "#b": "2" } });
+    assert.equal(failed.errorCode, "target_not_found");
+    assert.match(failed.error, /#a, #b/);
+
+    const partial = loadContent(el("body", {}, [field]), {
+        querySelector: (selector) => (selector === "#a" ? field : null),
+    });
+    const mixed = await partial("form_input", { fields: { "#a": "1", "#b": "2" } });
+    assert.equal(mixed.error, null);
+    assert.match(mixed.data, /#a: filled/);
+    assert.match(mixed.data, /#b: not found/);
+});
+
+test("form_input requires at least one field", async () => {
+    const response = await loadContent(el("body", {}, []))("form_input", { fields: {} });
+
+    assert.equal(response.errorCode, "invalid_input");
+    assert.equal(response.recoveryAction, "fix_input");
+});
+
+// ─── Required arguments ──────────────────────────────────────────────
+
+test("missing required arguments return invalid_input, not a raw TypeError", async () => {
+    const call = loadContent(el("body", {}, []));
+
+    for (const [action, params] of [
+        ["press_key", {}],
+        ["click", {}],
+        ["hover", {}],
+        ["scroll", {}],
+        ["drag", {}],
+    ]) {
+        const response = await call(action, params);
+        assert.equal(response.errorCode, "invalid_input", `${action} should reject cleanly`);
+        assert.equal(response.recoveryAction, "fix_input", `${action} should say how to recover`);
+        assert.equal(response.data, null);
+    }
+});
+
+test("press_key reports physical key codes for digits and letters", async () => {
+    const events = [];
+    const body = el("body", {}, []);
+    body.dispatchEvent = (event) => { events.push(event); return true; };
+    const call = loadContent(body, { activeElement: null, body });
+
+    await call("press_key", { key: "1" });
+    await call("press_key", { key: "a" });
+    await call("press_key", { key: "Enter" });
+
+    assert.equal(events[0].code, "Digit1");
+    assert.equal(events[3].code, "KeyA");
+    assert.equal(events[6].code, "Enter");
+});
+
+test("scroll treats amount 0 as an explicit no-op distance", async () => {
+    const call = loadContent(el("body", {}, []));
+
+    const response = await call("scroll", { direction: "down", amount: 0 });
+
+    assert.equal(response.error, null);
+    assert.match(response.data, /Scrolled down by 0px/);
+    assert.equal(call.scrolls[0].top, 0);
+    assert.equal(call.scrolls[0].left, 0);
+});


### PR DESCRIPTION
Seven defects found while auditing the content layer, each verified by executing the real `content.js` / `console-interceptor.js` against a fake DOM before and after the fix.

## Security

`snapshot` reported the contents of every input with a value, including `<input type="password">`. A snapshot of a filled login form handed the credential straight to the model. Password inputs, and inputs whose `autocomplete` marks them as a password, one-time code, or payment card field, now report `"value": "[redacted]"`. Every other value is unchanged.

## Silent no-ops reported as success

- **`select_option`** — assigning an unmatched value to a `<select>` clears the selection rather than throwing, so `select_option({value: "nope"})` returned `Selected option in #s` while nothing was selected. It now fails with `target_not_found` and restores the previous selection.
- **`form_input`** — returned success with a body reading `#a: not found\n#b: not found`. Filling nothing is now `target_not_found`; a partial fill still succeeds and reports per-field results.
- **`read_console({pattern, clear: true})`** — the clear branch only honored `level`, so it emptied the whole buffer and discarded messages the caller never saw. It now clears exactly the set it returned. The existing comment already claimed this behavior.

## Unbounded and unstructured results

- **`find`** — the `selector` strategy was uncapped while `text` and `role` capped at 20 and 50. All three now share one 50-match cap, and the tool description says so.
- **Missing required arguments** — `press_key({})` returned `Cannot read properties of undefined (reading 'split')` as an `extension_error`. `press_key`, `click`, `hover`, `scroll`, `drag`, `select_option`, and `form_input` now return `invalid_input` / `fix_input`, matching what `find` already did.

## Accessible name resolution

`getAccessibleName` interpolated the raw element id into ``label[for="${element.id}"]``. An id containing a quote builds a malformed selector, which throws in a real DOM — and because `buildTree` calls it for every element, one such id failed the entire page's snapshot. Ids are now escaped, labelable controls resolve through `element.labels` first, and `aria-labelledby` resolves its full space-separated id list instead of only the first.

Also folded in two one-line correctness fixes in the same functions: `press_key` reports `Digit1` rather than `Key1` for digits, and `scroll` treats `amount: 0` as an explicit distance instead of falling back to the viewport height.

## Validation

`swift build`, `swift test` (18), `node --test Tests/*.mjs` (42, 17 new), `node --check` on both changed extension scripts, `git diff --check`.

The new tests fail against the previous behavior — each one was written against the bug first.

Not verified locally: the signed `xcodebuild` extension build, which CI covers.
