### PR TITLE
fix: make type_text work in model-backed editors and unbreak native input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 - `type_text` now inserts into model-backed editors (ProseMirror, Lexical, Slate) by driving `document.execCommand("insertText")`, falling back to `beforeinput`/`input` events carrying `inputType` and `data`, instead of a direct DOM mutation with a bare `input` event those editors discard on the next render.
 - `type_text` now fails with `input_not_applied` when non-empty text left the target unchanged, instead of reporting success.
-- Fixed native typing (`native: true`) always failing with `native_input_focus_lost` while Safari was frontmost: the frontmost check read an `NSWorkspace` value frozen at the server's first access, and is now refreshed by pumping the main run loop before reading. The check also runs once before and once after typing instead of per keystroke, and the tool description no longer claims native input foregrounds Safari.
+- Fixed native typing (`native: true`) always failing with `native_input_focus_lost` while Safari was frontmost: the frontmost check now reads activation state fresh on every call instead of an NSWorkspace value cached at first touch, and runs once before and once after typing instead of per keystroke, and the tool description no longer claims native input foregrounds Safari.
 - `select_option` now fails with `target_not_found` instead of reporting success when the requested value matches no option, and restores the previous selection.
 - `form_input` now fails with `target_not_found` when no field matched, instead of returning a successful result whose body reads `not found`.
 - `read_console` with `clear` now removes only the messages the call returned, so a level- or pattern-filtered read no longer discards unread messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
 
 ### Bug Fixes
+- `type_text` now inserts into model-backed editors (ProseMirror, Lexical, Slate) by driving `document.execCommand("insertText")`, falling back to `beforeinput`/`input` events carrying `inputType` and `data`, instead of a direct DOM mutation with a bare `input` event those editors discard on the next render.
+- `type_text` now fails with `input_not_applied` when non-empty text left the target unchanged, instead of reporting success.
+- Fixed native typing (`native: true`) always failing with `native_input_focus_lost` while Safari was frontmost: the frontmost check read an `NSWorkspace` value frozen at the server's first access, and is now refreshed by pumping the main run loop before reading. The check also runs once before and once after typing instead of per keystroke, and the tool description no longer claims native input foregrounds Safari.
 - `select_option` now fails with `target_not_found` instead of reporting success when the requested value matches no option, and restores the previous selection.
 - `form_input` now fails with `target_not_found` when no field matched, instead of returning a successful result whose body reads `not found`.
 - `read_console` with `clear` now removes only the messages the call returned, so a level- or pattern-filtered read no longer discards unread messages.

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -625,8 +625,7 @@
 
     function setInputValue(el, value, append = false) {
         if (el.isContentEditable) {
-            el.textContent = append ? el.textContent + value : value;
-            el.dispatchEvent(new Event("input", { bubbles: true }));
+            setEditableText(el, value, append);
             return;
         }
 
@@ -649,6 +648,44 @@
         // Dispatch events that React and other frameworks listen for
         el.dispatchEvent(new Event("input", { bubbles: true }));
         el.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+
+    // Model-backed editors (ProseMirror, Lexical, Slate) apply edits from the
+    // inputType/data on beforeinput/input and re-render from their own
+    // document, discarding direct DOM mutation. execCommand("insertText")
+    // produces those events, so the edit survives; a bare `input` carrying
+    // neither field does not.
+    function setEditableText(el, value, append) {
+        if (append && value === "") return;
+
+        const selection = window.getSelection();
+        const caretInside = selection.rangeCount > 0
+            && el.contains(selection.getRangeAt(0).startContainer);
+        if (!append || !caretInside) {
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            if (append) range.collapse(false);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }
+
+        const applied = value === ""
+            ? document.execCommand("delete", false)
+            : document.execCommand("insertText", false, value);
+        if (applied) return;
+
+        // execCommand returns false when the edit is refused (e.g. a canceled
+        // beforeinput); synthesize the same edit shape ourselves.
+        const detail = {
+            bubbles: true,
+            inputType: value === "" ? "deleteContentBackward" : "insertText",
+            data: value || null,
+        };
+        const before = new InputEvent("beforeinput", { ...detail, cancelable: true });
+        if (el.dispatchEvent(before)) {
+            el.textContent = append ? el.textContent + value : value;
+        }
+        el.dispatchEvent(new InputEvent("input", detail));
     }
 
     // ─── Type Text ───────────────────────────────────────────────────
@@ -709,12 +746,32 @@
 
         el.focus();
 
+        const readBack = () => (el.isContentEditable ? el.textContent : el.value);
+        const before = readBack();
+
         if (params.clearFirst) {
             setInputValue(el, "", false);
         }
 
         const text = params.text || "";
         setInputValue(el, text, !params.clearFirst);
+
+        // An editor that re-renders from its own model can discard the edit
+        // after reporting nothing; success must mean the content changed.
+        // A detached element cannot be re-read meaningfully, and clearFirst
+        // with identical text legitimately produces no difference.
+        const unchanged = text !== ""
+            && el.isConnected !== false
+            && readBack() === before
+            && !(params.clearFirst && text === before);
+        if (unchanged) {
+            throw toolError(
+                "input_not_applied",
+                `Typing did not change <${el.tagName.toLowerCase()}>; the page discarded or blocked the input`,
+                false,
+                "use_native_input"
+            );
+        }
 
         // Press a key after typing (e.g., Enter, Tab)
         if (params.submitKey) {

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -970,21 +970,12 @@ actor SafariMCPServer {
     }
 
     private nonisolated static func ensureSafariIsFrontmost(afterTyping: Bool = false) throws {
-        // NSWorkspace's frontmost state is notification-backed and never
-        // updates in a process that does not pump the main run loop, so
-        // without this the value stays frozen at whatever was frontmost when
-        // the server first touched NSWorkspace — usually the MCP client's
-        // terminal — and the guard can never pass. Pumping the current
-        // (pool) thread's run loop is not enough; the notifications are
-        // delivered through the main run loop's sources.
-        if Thread.isMainThread {
-            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
-        } else {
-            DispatchQueue.main.sync {
-                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
-            }
-        }
-        guard NSWorkspace.shared.frontmostApplication?.bundleIdentifier == "com.apple.Safari" else {
+        // NSWorkspace.frontmostApplication freezes at first touch in this
+        // run-loop-less process; a fresh fetch reads current state.
+        let safariIsActive = NSRunningApplication
+            .runningApplications(withBundleIdentifier: "com.apple.Safari")
+            .contains { $0.isActive }
+        guard safariIsActive else {
             throw NativeInputError(failure: ToolFailure(
                 code: "native_input_focus_lost",
                 message: afterTyping

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -327,7 +327,7 @@ actor SafariMCPServer {
                         "clearFirst": .object(["type": .string("boolean")]),
                         "native": .object([
                             "type": .string("boolean"),
-                            "description": .string("Use real macOS key events; foregrounds Safari and requires Accessibility permission"),
+                            "description": .string("Use real macOS key events; requires Safari to already be the frontmost application and Accessibility permission"),
                         ]),
                         "submitKey": .object(["type": .string("string"), "description": .string("Key after typing (Enter, Tab)")]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
@@ -945,13 +945,16 @@ actor SafariMCPServer {
         }
         for character in input.text {
             try checkDeadline()
-            try ensureSafariIsFrontmost()
             try postText(String(character), source: source)
         }
         if let submitKeyCode = input.submitKeyCode {
             try checkDeadline()
             try postKey(code: submitKeyCode, source: source)
         }
+        // One check before and one after typing: a per-keystroke re-check
+        // would abort mid-word on any transient focus blip without saying
+        // how much was delivered.
+        try ensureSafariIsFrontmost(afterTyping: true)
 
         let suffix = input.submitKey.map { " then pressed \($0)" } ?? ""
         return "Typed \(input.text.count) character(s) with native input\(suffix)"
@@ -966,11 +969,27 @@ actor SafariMCPServer {
         }
     }
 
-    private nonisolated static func ensureSafariIsFrontmost() throws {
+    private nonisolated static func ensureSafariIsFrontmost(afterTyping: Bool = false) throws {
+        // NSWorkspace's frontmost state is notification-backed and never
+        // updates in a process that does not pump the main run loop, so
+        // without this the value stays frozen at whatever was frontmost when
+        // the server first touched NSWorkspace — usually the MCP client's
+        // terminal — and the guard can never pass. Pumping the current
+        // (pool) thread's run loop is not enough; the notifications are
+        // delivered through the main run loop's sources.
+        if Thread.isMainThread {
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+        } else {
+            DispatchQueue.main.sync {
+                RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1))
+            }
+        }
         guard NSWorkspace.shared.frontmostApplication?.bundleIdentifier == "com.apple.Safari" else {
             throw NativeInputError(failure: ToolFailure(
                 code: "native_input_focus_lost",
-                message: "Safari lost focus before native typing completed. Input may be partial; focus the target and retry.",
+                message: afterTyping
+                    ? "Safari lost focus during native typing. Some keystrokes may have gone to another application; verify the target and retry."
+                    : "Safari is not the frontmost application. Native key events go to whichever app has focus; activate Safari and retry. Nothing was typed.",
                 retryable: true,
                 recoveryAction: "retry"
             ))
@@ -1007,7 +1026,6 @@ actor SafariMCPServer {
         flags: CGEventFlags = [],
         source: CGEventSource
     ) throws {
-        try ensureSafariIsFrontmost()
         guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: true),
               let keyUp = CGEvent(keyboardEventSource: source, virtualKey: code, keyDown: false)
         else {

--- a/Tests/content-tool-safety.test.mjs
+++ b/Tests/content-tool-safety.test.mjs
@@ -45,7 +45,7 @@ function el(tag, options = {}, children = []) {
     return node;
 }
 
-function loadContent(body, documentOverrides = {}) {
+function loadContent(body, documentOverrides = {}, windowOverrides = {}) {
     let listener;
     const document = {
         body,
@@ -54,6 +54,8 @@ function loadContent(body, documentOverrides = {}) {
         getElementById: () => null,
         querySelector: () => null,
         querySelectorAll: () => [],
+        execCommand: () => false,
+        createRange: () => ({ selectNodeContents() {}, collapse() {} }),
         createTreeWalker(root, _show, filter) {
             const queue = [];
             const collect = (n) => { for (const c of n.children) { queue.push(c); collect(c); } };
@@ -90,6 +92,7 @@ function loadContent(body, documentOverrides = {}) {
         Event: FakeEvent,
         KeyboardEvent: FakeEvent,
         MouseEvent: FakeEvent,
+        InputEvent: FakeEvent,
         // No native `value` descriptor, so setInputValue takes its direct-assign path.
         HTMLInputElement: class {},
         HTMLTextAreaElement: class {},
@@ -100,6 +103,13 @@ function loadContent(body, documentOverrides = {}) {
             innerHeight: 800,
             scrollBy: (options) => scrolls.push(options),
             getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+            getSelection: () => ({
+                rangeCount: 0,
+                removeAllRanges() {},
+                addRange() {},
+                getRangeAt() { return null; },
+            }),
+            ...windowOverrides,
         },
     });
 
@@ -298,6 +308,86 @@ test("press_key reports physical key codes for digits and letters", async () => 
     assert.equal(events[0].code, "Digit1");
     assert.equal(events[3].code, "KeyA");
     assert.equal(events[6].code, "Enter");
+});
+
+// ─── type_text ───────────────────────────────────────────────────────
+
+function editableHarness({ execCommand } = {}) {
+    const events = [];
+    const target = el("div", {
+        id: "ce",
+        extra: {
+            isContentEditable: true,
+            textContent: "",
+            contains: () => false,
+            dispatchEvent(event) {
+                events.push(event);
+                return true;
+            },
+        },
+    });
+    const commands = [];
+    const call = loadContent(el("body", {}, [target]), {
+        querySelector: () => target,
+        execCommand: (command, _ui, value) => {
+            commands.push({ command, value });
+            return execCommand ? execCommand(target, command, value) : false;
+        },
+    });
+    return { target, events, commands, call };
+}
+
+test("type_text drives contenteditable through execCommand insertText", async () => {
+    const { target, commands, call } = editableHarness({
+        execCommand: (el2, command, value) => {
+            if (command === "insertText") el2.textContent += value;
+            return true;
+        },
+    });
+
+    const response = await call("type_text", { selector: "#ce", text: "hello" });
+
+    assert.equal(response.error, null);
+    assert.deepEqual(commands, [{ command: "insertText", value: "hello" }]);
+    assert.equal(target.textContent, "hello");
+});
+
+test("type_text falls back to beforeinput/input carrying inputType and data", async () => {
+    const { target, events, call } = editableHarness();
+
+    const response = await call("type_text", { selector: "#ce", text: "abc" });
+
+    assert.equal(response.error, null);
+    assert.equal(target.textContent, "abc");
+    const [beforeInput, input] = events;
+    assert.equal(beforeInput.type, "beforeinput");
+    assert.equal(beforeInput.inputType, "insertText");
+    assert.equal(beforeInput.data, "abc");
+    assert.equal(beforeInput.cancelable, true);
+    assert.equal(input.type, "input");
+    assert.equal(input.inputType, "insertText");
+    assert.equal(input.data, "abc");
+});
+
+test("type_text fails when the editor discards the input", async () => {
+    // execCommand claims success but the content never changes — the
+    // model-backed-editor case that used to report a false success.
+    const { call } = editableHarness({ execCommand: () => true });
+
+    const response = await call("type_text", { selector: "#ce", text: "hello" });
+
+    assert.equal(response.errorCode, "input_not_applied");
+    assert.equal(response.recoveryAction, "use_native_input");
+});
+
+test("type_text accepts clearFirst retyping the identical value", async () => {
+    const field = el("input", { id: "a", extra: { type: "text", value: "abc" } });
+    const call = loadContent(el("body", {}, [field]), { querySelector: () => field });
+
+    const response = await call("type_text", { selector: "#a", text: "abc", clearFirst: true });
+
+    assert.equal(response.error, null);
+    assert.equal(field.value, "abc");
 });
 
 test("scroll treats amount 0 as an explicit no-op distance", async () => {


### PR DESCRIPTION
**Problem**

`type_text` can't get text into Notion-style editors at all. Synthetic typing reports success but the text vanishes; `native: true` always fails with `native_input_focus_lost` even when Safari is frontmost.

**Root cause**

The synthetic path mutates the DOM and fires a bare `input` with no `inputType`/`data`, so ProseMirror/Lexical editors re-render and throw the text away. The native path's `frontmostApplication` read freezes at first access in a run-loop-less process, so the guard compares against the terminal forever.

**Fix**

Contenteditable typing now goes through `execCommand("insertText")` (fallback: `beforeinput`/`input` with `inputType`/`data`), and `type_text` errors with `input_not_applied` if the text didn't stick. The frontmost check pumps the main run loop first and runs before/after typing instead of per keystroke. Also dropped the description's claim that native input foregrounds Safari.

**Validation**

50 Node + 31 Swift tests, release build, unsigned xcodebuild. On a real install: native typing refuses with Finder frontmost, types cleanly with Safari frontmost; synthetic typing survives prosemirror.net and a live Notion page.
