### PR TITLE
fix: surface javascript_tool runtime errors instead of returning null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `find` without `selector`, `text`, or `role` now returns `invalid_input` instead of an empty result that looks like a failed match.
 - Fixed `snapshot` crashing on SVG elements with non-string `type` properties.
 - Retried trace startup once after an interceptor timeout so a transient `start_trace interceptor did not respond` failure no longer aborts the traced action.
+- `javascript_tool` now surfaces runtime throws and rejected promises as tool errors instead of returning `null`; the tool description documents that multi-statement code needs an explicit `return` to produce a value.
 
 ### Build
 - Updated SwiftPM dependencies, including MCP Swift SDK 0.12.1, SwiftLog 1.14.0, and SwiftNIO 2.101.3.

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -645,7 +645,9 @@ async function handleJavaScript(params) {
                 } catch (_) {
                     fn = new Function(`return (async () => { ${code} })()`);
                 }
-                return fn();
+                return fn().catch((e) => ({
+                    __error: e && e.message ? e.message : String(e),
+                }));
             } catch (e) {
                 return { __error: e.message };
             }

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -465,7 +465,7 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "javascript_tool",
-                description: "Execute JS in page context. Returns expression results.",
+                description: "Execute JS in page context. A single expression returns its value; a multi-statement body must end in an explicit `return` to produce a value.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 
 | Tool | Description |
 |------|-------------|
-| `javascript_tool` | Execute arbitrary JS in the page context and return expression results |
+| `javascript_tool` | Execute arbitrary JS in the page context and return expression results; multi-statement code must end in an explicit `return` to produce a value |
 
 ### Debugging
 

--- a/Tests/background-javascript.test.mjs
+++ b/Tests/background-javascript.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const backgroundSource = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/background.js", import.meta.url),
+    "utf8"
+);
+
+function backgroundHarness() {
+    class FakeWebSocket {
+        static CONNECTING = 0;
+        constructor(url) {
+            this.url = url;
+            this.readyState = FakeWebSocket.CONNECTING;
+        }
+        send() {}
+    }
+
+    const browser = {
+        alarms: {
+            create() {},
+            onAlarm: { addListener() {} },
+        },
+        runtime: {
+            getManifest: () => ({ version: "9.9.9" }),
+            onMessage: { addListener() {} },
+            sendNativeMessage: async () => ({ tokens: {} }),
+        },
+        scripting: {
+            executeScript: async ({ func, args }) => [{ result: await func(...args) }],
+        },
+        storage: {
+            local: { get: async () => ({}), set() {} },
+            session: { get: async () => ({}), set() {}, remove: async () => {} },
+        },
+        tabs: {
+            get: async () => { throw new Error("not found"); },
+            onUpdated: { addListener() {}, removeListener() {} },
+        },
+    };
+
+    const context = vm.createContext({
+        browser,
+        clearTimeout() {},
+        console: { error() {}, log() {}, warn() {} },
+        Date,
+        Promise,
+        setTimeout() {},
+        WebSocket: FakeWebSocket,
+    });
+    vm.runInContext(backgroundSource, context);
+
+    return (code) => vm.runInContext(
+        `handleJavaScript({ tabId: 1, code: ${JSON.stringify(code)} })`,
+        context
+    );
+}
+
+test("plain expression returns its value", async () => {
+    const run = backgroundHarness();
+    assert.equal(await run("1 + 1"), "2");
+});
+
+test("statement body with explicit return returns its value", async () => {
+    const run = backgroundHarness();
+    const code = "const a = await Promise.resolve(41); const b = a + 1; return JSON.stringify({ b })";
+    assert.equal(await run(code), '"{\\"b\\":42}"');
+});
+
+test("statement body without return yields no value", async () => {
+    const run = backgroundHarness();
+    const code = "const x = 1; const y = 2; JSON.stringify({ sum: x + y })";
+    assert.equal(await run(code), "undefined");
+});
+
+test("sync throw in a statement body surfaces as an error", async () => {
+    const run = backgroundHarness();
+    await assert.rejects(run('throw new Error("boom-sync")'), /boom-sync/);
+});
+
+test("awaited rejection surfaces as an error", async () => {
+    const run = backgroundHarness();
+    const code = "const p = Promise.reject(new Error('boom-async')); return await p";
+    await assert.rejects(run(code), /boom-async/);
+});
+
+test("non-Error rejection surfaces its string form", async () => {
+    const run = backgroundHarness();
+    await assert.rejects(run("return Promise.reject('boom-string')"), /boom-string/);
+});
+
+test("parse errors still surface", async () => {
+    const run = backgroundHarness();
+    await assert.rejects(run("const a = 1; this is not valid js; return a"), /Unexpected identifier/);
+});
+
+test("async IIFE expression keeps working", async () => {
+    const run = backgroundHarness();
+    const code = "(async () => { const a = await Promise.resolve(41); return JSON.stringify({ b: a + 1 }) })()";
+    assert.equal(await run(code), '"{\\"b\\":42}"');
+});


### PR DESCRIPTION
## Problem

`javascript_tool` returns bare `null` for code that throws or rejects at runtime — indistinguishable from code that ran and produced no value. Fixes #41.

## Root cause

The injected function in `background.js` returns the async-IIFE promise from `fn()`. `browser.scripting.executeScript` awaits it, but the `catch` guarding the `{__error}` path is synchronous, so a rejection never reaches it and the call resolves as `null`. Parse errors were unaffected because `new Function` throws synchronously.

## Fix

`.catch` the promise from `fn()` into the same `{__error}` object the synchronous path already returns, with a `String(e)` fallback so non-Error rejections (`Promise.reject("msg")`) still produce a message. The tool description and README now document that a multi-statement body must end in an explicit `return` — the statement-wrap fallback discards the completion value, and recovering it via direct `eval` fails because JSC rejects `await` inside a direct eval (`SyntaxError: Unexpected identifier 'Promise'`), so that half is documentation, not code. Net +6/−3 lines across four files.

## Validation

- 8 new VM tests in `Tests/background-javascript.test.mjs` covering the issue's probe table: sync throw, awaited rejection, non-Error rejection, parse error, explicit-return body, return-less body, plain expression, async IIFE.
- `node --test Tests/*.mjs` 54/54; `swift test` 31/31; `swift build -c release`; unsigned `xcodebuild` with the CI invocation; `node --check` on all extension scripts.
