### PR TITLE
feat: add opt-in resource timings and filters to read_network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,10 @@
 - Added `upload_file` and `drop_file` for attaching explicit local files to a file input or dropping them onto an element.
 - Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
 - `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
+- `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries with zeroed size and timing fields are marked `timingRestricted: true`.
 
 ### Bug Fixes
+- `read_network` with `clear` now removes only the entries the call returned, so a type- or URL-filtered clear no longer discards requests the caller never saw (matching `read_console`).
 - Stop stale per-port token files from causing endless extension reconnect attempts and popup state cycling.
 - Read the popup version from its manifest, keep ports ordered, and use adaptive system colors for legibility on Safari glass.
 - Reinject the content script when Safari returns no message-listener response instead of reporting a successful `null` result.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Added `upload_file` and `drop_file` for attaching explicit local files to a file input or dropping them onto an element.
 - Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
 - `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
-- `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries with zeroed size and timing fields are marked `timingRestricted: true`.
+- `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries whose byte counts are withheld are marked `timingRestricted: true`.
 
 ### Bug Fixes
 - `read_network` with `clear` now removes only the entries the call returned, so a type- or URL-filtered clear no longer discards requests the caller never saw (matching `read_console`).

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -303,6 +303,9 @@ async function handleRequest(request) {
                     action: "get_network_requests",
                     params: {
                         type: params.type || "all",
+                        urlPattern: params.urlPattern || null,
+                        status: params.status ?? null,
+                        maxResults: params.maxResults || 0,
                         clear: params.clear || false,
                     },
                 });

--- a/MCPSafari/MCPSafari Extension/Resources/network-interceptor.js
+++ b/MCPSafari/MCPSafari Extension/Resources/network-interceptor.js
@@ -1,8 +1,8 @@
 /**
  * MCPSafari Network Interceptor
  *
- * Patches XMLHttpRequest and fetch to capture network requests
- * for the read_network tool. Injected at document_start.
+ * Captures XMLHttpRequest, fetch, and resource timings for the
+ * read_network tool. Injected at document_start.
  */
 (() => {
     if (window.__mcpNetworkInterceptorLoaded) return;
@@ -10,6 +10,7 @@
 
     const MAX_REQUESTS = 500;
     const requests = [];
+    const resources = [];
 
     function recordTraceEvent(type, request) {
         try {
@@ -26,6 +27,42 @@
             }
         } catch (_) { /* trace capture must not affect network behavior */ }
     }
+
+    // Cross-origin entries without Timing-Allow-Origin report zeroed size and
+    // timing fields; mark them so zeros read as "not permitted", not "cache hit".
+    function isTimingRestricted(entry) {
+        try {
+            if (new URL(entry.name).origin === location.origin) return false;
+        } catch {
+            return false;
+        }
+        return entry.transferSize === 0
+            && entry.encodedBodySize === 0
+            && entry.decodedBodySize === 0
+            && entry.duration === 0;
+    }
+
+    function recordResources(entries) {
+        for (const entry of entries) {
+            if (resources.length >= MAX_REQUESTS) resources.shift();
+            const record = {
+                type: "resource",
+                url: entry.name,
+                initiatorType: entry.initiatorType,
+                transferSize: entry.transferSize,
+                encodedBodySize: entry.encodedBodySize,
+                decodedBodySize: entry.decodedBodySize,
+                startTime: entry.startTime,
+                duration: entry.duration,
+                timestamp: performance.timeOrigin + entry.startTime,
+            };
+            if (isTimingRestricted(entry)) record.timingRestricted = true;
+            resources.push(record);
+        }
+    }
+
+    const resourceObserver = new PerformanceObserver((list) => recordResources(list.getEntries()));
+    resourceObserver.observe({ type: "resource", buffered: true });
 
     // ─── XMLHttpRequest Interception ─────────────────────────────────
 
@@ -119,14 +156,40 @@
     // ─── API for content script ──────────────────────────────────────
 
     window.__mcpGetNetworkRequests = (params = {}) => {
-        let filtered = [...requests];
+        recordResources(resourceObserver.takeRecords());
+        const selected = params.type === "resource" ? resources : requests;
+        let filtered = [...selected];
 
         if (params.type && params.type !== "all") {
             filtered = filtered.filter((r) => r.type === params.type);
         }
 
+        if (params.urlPattern) {
+            try {
+                const regex = new RegExp(params.urlPattern);
+                filtered = filtered.filter((r) => regex.test(r.url));
+            } catch {
+                // Invalid regex, ignore filter
+            }
+        }
+
+        if (params.status != null) {
+            filtered = filtered.filter((r) => r.status === params.status);
+        }
+
+        if (params.maxResults > 0) {
+            filtered = filtered.slice(-params.maxResults);
+        }
+
         if (params.clear) {
-            requests.length = 0;
+            // Clear exactly what this call returned, so a filtered read
+            // never discards entries the caller never saw.
+            const returned = new Set(filtered);
+            for (let i = selected.length - 1; i >= 0; i--) {
+                if (returned.has(selected[i])) {
+                    selected.splice(i, 1);
+                }
+            }
         }
 
         return filtered;

--- a/MCPSafari/MCPSafari Extension/Resources/network-interceptor.js
+++ b/MCPSafari/MCPSafari Extension/Resources/network-interceptor.js
@@ -28,8 +28,10 @@
         } catch (_) { /* trace capture must not affect network behavior */ }
     }
 
-    // Cross-origin entries without Timing-Allow-Origin report zeroed size and
-    // timing fields; mark them so zeros read as "not permitted", not "cache hit".
+    // Cross-origin entries without Timing-Allow-Origin report zeroed byte counts;
+    // mark them so zeros read as "not permitted", not "cache hit". `duration` is
+    // deliberately not part of the test: the spec leaves startTime and responseEnd
+    // readable for these entries, so a restricted resource still times normally.
     function isTimingRestricted(entry) {
         try {
             if (new URL(entry.name).origin === location.origin) return false;
@@ -38,8 +40,7 @@
         }
         return entry.transferSize === 0
             && entry.encodedBodySize === 0
-            && entry.decodedBodySize === 0
-            && entry.duration === 0;
+            && entry.decodedBodySize === 0;
     }
 
     function recordResources(entries) {
@@ -61,8 +62,15 @@
         }
     }
 
-    const resourceObserver = new PerformanceObserver((list) => recordResources(list.getEntries()));
-    resourceObserver.observe({ type: "resource", buffered: true });
+    // Resource timing is an opt-in extra, so it must not be able to take the
+    // XHR and fetch patching below down with it if the observer is unavailable.
+    let resourceObserver = null;
+    try {
+        resourceObserver = new PerformanceObserver((list) => recordResources(list.getEntries()));
+        resourceObserver.observe({ type: "resource", buffered: true });
+    } catch (_) {
+        resourceObserver = null;
+    }
 
     // ─── XMLHttpRequest Interception ─────────────────────────────────
 
@@ -156,7 +164,7 @@
     // ─── API for content script ──────────────────────────────────────
 
     window.__mcpGetNetworkRequests = (params = {}) => {
-        recordResources(resourceObserver.takeRecords());
+        if (resourceObserver) recordResources(resourceObserver.takeRecords());
         const selected = params.type === "resource" ? resources : requests;
         let filtered = [...selected];
 

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -491,11 +491,14 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "read_network",
-                description: "Read captured XHR/fetch requests.",
+                description: "Read captured XHR/fetch requests; use type resource for resource timings (no status or headers). Filter with urlPattern (regex), status, and maxResults (most recent N).",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
-                        "type": .object(["type": .string("string"), "enum": .array([.string("all"), .string("xhr"), .string("fetch")])]),
+                        "type": .object(["type": .string("string"), "enum": .array([.string("all"), .string("xhr"), .string("fetch"), .string("resource")])]),
+                        "urlPattern": .object(["type": .string("string"), "description": .string("Regex filter on URL")]),
+                        "status": .object(["type": .string("integer"), "description": .string("Filter by HTTP status code (fetch/xhr only; 0 means network error)")]),
+                        "maxResults": .object(["type": .string("integer"), "description": .string("Return at most this many most recent entries")]),
                         "clear": .object(["type": .string("boolean")]),
                         "tabId": Self.tab,
                     ]),
@@ -676,7 +679,7 @@ actor SafariMCPServer {
     private static let allowedNavActions: Set<String> = ["goto", "back", "forward", "reload"]
     private static let allowedPageFormats: Set<String> = ["text", "html", "snapshot"]
     private static let allowedConsoleLevels: Set<String> = ["all", "log", "warn", "error", "info", "debug"]
-    private static let allowedNetworkTypes: Set<String> = ["all", "xhr", "fetch"]
+    private static let allowedNetworkTypes: Set<String> = ["all", "xhr", "fetch", "resource"]
 
     private func handleNavigate(_ args: [String: Value]) async throws -> CallTool.Result {
         var params: [String: AnyCodable] = [:]
@@ -1233,11 +1236,44 @@ actor SafariMCPServer {
         if let type = args["type"]?.stringValue {
             guard Self.allowedNetworkTypes.contains(type) else {
                 return CallTool.Result(
-                    content: [Self.textContent("Invalid network type: \(type). Use all, xhr, or fetch.")],
+                    content: [Self.textContent("Invalid network type: \(type). Use all, xhr, fetch, or resource.")],
                     isError: true
                 )
             }
             params["type"] = AnyCodable(type)
+        }
+        if let urlPattern = args["urlPattern"]?.stringValue {
+            guard urlPattern.count <= 200 else {
+                return CallTool.Result(
+                    content: [Self.textContent("URL pattern too long (max 200 characters)")],
+                    isError: true
+                )
+            }
+            guard (try? NSRegularExpression(pattern: urlPattern)) != nil else {
+                return CallTool.Result(
+                    content: [Self.textContent("Invalid regex pattern: \(urlPattern)")],
+                    isError: true
+                )
+            }
+            params["urlPattern"] = AnyCodable(urlPattern)
+        }
+        if let status = args["status"]?.intValue {
+            guard (0...599).contains(status) else {
+                return CallTool.Result(
+                    content: [Self.textContent("Invalid status: \(status). Use an HTTP status code (0-599; 0 means network error).")],
+                    isError: true
+                )
+            }
+            params["status"] = AnyCodable(status)
+        }
+        if let maxResults = args["maxResults"]?.intValue {
+            guard maxResults > 0 else {
+                return CallTool.Result(
+                    content: [Self.textContent("Invalid maxResults: \(maxResults). Use a positive integer.")],
+                    isError: true
+                )
+            }
+            params["maxResults"] = AnyCodable(maxResults)
         }
         if let clear = args["clear"]?.boolValue { params["clear"] = AnyCodable(clear) }
         let response = try await bridge.send(action: "read_network", params: params)

--- a/README.md
+++ b/README.md
@@ -290,9 +290,11 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 | Tool | Description |
 |------|-------------|
 | `read_console` | Read console messages with level and regex filtering |
-| `read_network` | Read captured XHR/fetch requests with type filtering |
+| `read_network` | Read captured XHR/fetch requests or opt-in resource timings with type, URL-regex, and count filtering |
 
 > **Note:** Console and network capture run in the page's main world (required to patch `console`, `fetch`, and `history`). A hostile page can therefore observe or forge this telemetry, so treat `read_console` / `read_network` output from untrusted pages as page-controlled data rather than ground truth.
+
+> **Note:** `read_network` with `type: "resource"` reports PerformanceObserver timings, not network-stack records: entries carry no HTTP status or request/response headers, and WebSocket traffic and redirect chains are not captured. Cross-origin entries without `Timing-Allow-Origin` report zeroed size and timing fields and are marked `timingRestricted: true`.
 
 ### Window
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 
 > **Note:** Console and network capture run in the page's main world (required to patch `console`, `fetch`, and `history`). A hostile page can therefore observe or forge this telemetry, so treat `read_console` / `read_network` output from untrusted pages as page-controlled data rather than ground truth.
 
-> **Note:** `read_network` with `type: "resource"` reports PerformanceObserver timings, not network-stack records: entries carry no HTTP status or request/response headers, and WebSocket traffic and redirect chains are not captured. Cross-origin entries without `Timing-Allow-Origin` report zeroed size and timing fields and are marked `timingRestricted: true`.
+> **Note:** `read_network` with `type: "resource"` reports PerformanceObserver timings, not network-stack records: entries carry no HTTP status or request/response headers, and WebSocket traffic and redirect chains are not captured. Cross-origin entries without `Timing-Allow-Origin` report zeroed byte counts and connection-phase timings — though `startTime` and `duration` stay accurate — and are marked `timingRestricted: true`.
 
 ### Window
 

--- a/Tests/network-interceptor.test.mjs
+++ b/Tests/network-interceptor.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/network-interceptor.js", import.meta.url),
+    "utf8"
+);
+
+function loadInterceptor() {
+    let observer;
+
+    class XMLHttpRequest {
+        open() {}
+        send() {}
+    }
+
+    class PerformanceObserver {
+        constructor() {
+            observer = { options: null, records: [] };
+        }
+
+        observe(options) {
+            observer.options = options;
+        }
+
+        takeRecords() {
+            return observer.records.splice(0);
+        }
+    }
+
+    const window = {
+        addEventListener() {},
+        fetch: async (input) => ({
+            status: String(input).includes("feed") ? 200 : 404,
+            statusText: "OK",
+        }),
+        postMessage() {},
+    };
+    window.window = window;
+
+    vm.runInNewContext(source, {
+        PerformanceObserver,
+        URL,
+        XMLHttpRequest,
+        location: { origin: "https://example.test" },
+        performance: { timeOrigin: 1_700_000_000_000 },
+        window,
+    });
+
+    return { observer, window };
+}
+
+test("resource reads expose buffered subresource timings without changing the default feed", () => {
+    const { observer, window } = loadInterceptor();
+
+    assert.deepEqual(JSON.parse(JSON.stringify(observer.options)), { type: "resource", buffered: true });
+    observer.records.push({
+        name: "https://example.test/image.png",
+        initiatorType: "img",
+        transferSize: 1234,
+        encodedBodySize: 934,
+        decodedBodySize: 2048,
+        startTime: 25,
+        duration: 7,
+    });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(window.__mcpGetNetworkRequests({ type: "resource" }))), [{
+        type: "resource",
+        url: "https://example.test/image.png",
+        initiatorType: "img",
+        transferSize: 1234,
+        encodedBodySize: 934,
+        decodedBodySize: 2048,
+        startTime: 25,
+        duration: 7,
+        timestamp: 1_700_000_000_025,
+    }]);
+    assert.deepEqual(Array.from(window.__mcpGetNetworkRequests({ type: "all" })), []);
+    window.__mcpGetNetworkRequests({ type: "resource", clear: true });
+    assert.deepEqual(Array.from(window.__mcpGetNetworkRequests({ type: "resource" })), []);
+});
+
+function pushResources(observer, urls) {
+    for (const [i, url] of urls.entries()) {
+        observer.records.push({
+            name: url,
+            initiatorType: "img",
+            transferSize: 0,
+            encodedBodySize: 0,
+            decodedBodySize: 0,
+            startTime: i,
+            duration: 1,
+        });
+    }
+}
+
+// Cross-realm results fail deepStrictEqual prototype checks; round-trip through JSON.
+function readNetwork(window, params) {
+    return JSON.parse(JSON.stringify(window.__mcpGetNetworkRequests(params)));
+}
+
+test("urlPattern filters resources by regex and ignores invalid patterns", () => {
+    const { observer, window } = loadInterceptor();
+    pushResources(observer, [
+        "https://example.test/variant-a.webp",
+        "https://example.test/original.png",
+        "https://example.test/variant-b.webp",
+    ]);
+
+    const matched = readNetwork(window, { type: "resource", urlPattern: "variant" });
+    assert.deepEqual(matched.map((r) => r.url), [
+        "https://example.test/variant-a.webp",
+        "https://example.test/variant-b.webp",
+    ]);
+
+    const unfiltered = readNetwork(window, { type: "resource", urlPattern: "([" });
+    assert.equal(unfiltered.length, 3);
+});
+
+test("maxResults returns the most recent entries", () => {
+    const { observer, window } = loadInterceptor();
+    pushResources(observer, [
+        "https://example.test/1.png",
+        "https://example.test/2.png",
+        "https://example.test/3.png",
+    ]);
+
+    const limited = readNetwork(window, { type: "resource", maxResults: 2 });
+    assert.deepEqual(limited.map((r) => r.url), [
+        "https://example.test/2.png",
+        "https://example.test/3.png",
+    ]);
+});
+
+test("clear with a filter removes only the returned entries", () => {
+    const { observer, window } = loadInterceptor();
+    pushResources(observer, [
+        "https://example.test/variant-a.webp",
+        "https://example.test/original.png",
+    ]);
+
+    const cleared = readNetwork(window, { type: "resource", urlPattern: "variant", clear: true });
+    assert.equal(cleared.length, 1);
+
+    const remaining = readNetwork(window, { type: "resource" });
+    assert.deepEqual(remaining.map((r) => r.url), ["https://example.test/original.png"]);
+});
+
+test("urlPattern also filters the fetch feed", async () => {
+    const { window } = loadInterceptor();
+    await window.fetch("https://example.test/api/feed");
+    await window.fetch("https://example.test/api/health");
+
+    const matched = readNetwork(window, { type: "fetch", urlPattern: "feed" });
+    assert.deepEqual(matched.map((r) => r.url), ["https://example.test/api/feed"]);
+
+    const limited = readNetwork(window, { maxResults: 1 });
+    assert.deepEqual(limited.map((r) => r.url), ["https://example.test/api/health"]);
+});
+
+test("status filters the fetch feed by HTTP status", async () => {
+    const { window } = loadInterceptor();
+    await window.fetch("https://example.test/api/feed");
+    await window.fetch("https://example.test/api/missing");
+
+    assert.deepEqual(readNetwork(window, { status: 200 }).map((r) => r.url), [
+        "https://example.test/api/feed",
+    ]);
+    assert.deepEqual(readNetwork(window, { status: 404 }).map((r) => r.url), [
+        "https://example.test/api/missing",
+    ]);
+});
+
+test("cross-origin entries with zeroed fields are marked timingRestricted", () => {
+    const { observer, window } = loadInterceptor();
+    observer.records.push(
+        // Cross-origin, all fields zeroed: Timing-Allow-Origin withheld.
+        { name: "https://cdn.other.test/a.png", initiatorType: "img", transferSize: 0, encodedBodySize: 0, decodedBodySize: 0, startTime: 1, duration: 0 },
+        // Cross-origin with real timing: TAO granted, no marker.
+        { name: "https://cdn.other.test/b.png", initiatorType: "img", transferSize: 0, encodedBodySize: 0, decodedBodySize: 500, startTime: 2, duration: 3 },
+        // Same-origin cache hit: legitimately zero, no marker.
+        { name: "https://example.test/cached.png", initiatorType: "img", transferSize: 0, encodedBodySize: 0, decodedBodySize: 0, startTime: 3, duration: 0 },
+    );
+
+    const entries = readNetwork(window, { type: "resource" });
+    assert.equal(entries[0].timingRestricted, true);
+    assert.equal(entries[1].timingRestricted, undefined);
+    assert.equal(entries[2].timingRestricted, undefined);
+});

--- a/Tests/network-interceptor.test.mjs
+++ b/Tests/network-interceptor.test.mjs
@@ -8,7 +8,7 @@ const source = readFileSync(
     "utf8"
 );
 
-function loadInterceptor() {
+function loadInterceptor({ observerThrows = false } = {}) {
     let observer;
 
     class XMLHttpRequest {
@@ -19,6 +19,7 @@ function loadInterceptor() {
     class PerformanceObserver {
         constructor() {
             observer = { options: null, records: [] };
+            if (observerThrows) throw new TypeError("PerformanceObserver unavailable");
         }
 
         observe(options) {
@@ -188,4 +189,36 @@ test("cross-origin entries with zeroed fields are marked timingRestricted", () =
     assert.equal(entries[0].timingRestricted, true);
     assert.equal(entries[1].timingRestricted, undefined);
     assert.equal(entries[2].timingRestricted, undefined);
+});
+
+test("a restricted entry is marked even though its duration is real", () => {
+    const { observer, window } = loadInterceptor();
+    // The timing allow check zeroes the byte counts and the connection-phase
+    // fields, but leaves startTime and responseEnd readable — so the ordinary
+    // uncached restricted resource has a real duration. Requiring duration === 0
+    // would mark only the cached ones and let this case read as a cache hit.
+    observer.records.push({
+        name: "https://cdn.other.test/uncached.png",
+        initiatorType: "img",
+        transferSize: 0,
+        encodedBodySize: 0,
+        decodedBodySize: 0,
+        startTime: 10,
+        duration: 143,
+    });
+
+    const [entry] = readNetwork(window, { type: "resource" });
+    assert.equal(entry.timingRestricted, true);
+    assert.equal(entry.duration, 143);
+});
+
+test("XHR and fetch capture still install when PerformanceObserver is unavailable", async () => {
+    const { window } = loadInterceptor({ observerThrows: true });
+
+    await window.fetch("https://example.test/api/feed");
+
+    assert.deepEqual(readNetwork(window, { type: "fetch" }).map((r) => r.url), [
+        "https://example.test/api/feed",
+    ]);
+    assert.deepEqual(readNetwork(window, { type: "resource" }), []);
 });


### PR DESCRIPTION
Implements the breadth half of #43 per https://github.com/Epistates/MCPSafari/issues/43#issuecomment-5143056613; bodies stay out as discussed there.

## Problem

`read_network` patches XHR and fetch and nothing else, so subresource loads are invisible and "no record" reads as "no request". Unfiltered, a real Vite dev page returns 489 entries (~139k chars) — over client output limits.

## Fix

- Opt-in `type: "resource"` feed from `PerformanceObserver` (`buffered: true`, 500-entry cap) with initiator type and byte sizes. Default feed unchanged.
- Cross-origin entries with zeroed fields (Timing-Allow-Origin withheld) get marked `timingRestricted: true`, so zeros don't read as cache hits.
- `urlPattern` (regex), `status`, and `maxResults` filters.
- `clear` now removes only returned entries, like `read_console`.
- README and tool description state the ceiling: no status, no headers, no WebSocket, no redirect chains.

## Validation

`node --test Tests/*.mjs` 65/65 (6 new), `swift test` 31/31. Verified on an installed build against a Vite-dev TanStack Start page (the #43 case): `maxResults` exact, `urlPattern` returned only img entries, `timingRestricted` set on real cross-origin r2.dev images and not same-origin ones, invalid regex rejected over the MCP path.
