### PR TITLE
fix: input fidelity for press_key, hover, and drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
 
 ### Bug Fixes
+- `press_key` and `type_text`'s `submitKey` no longer emit `keypress` for keys that produce no character (Escape, Tab, arrow keys) or for Ctrl/Meta combos, matching the UI Events spec; single characters and Enter still fire it.
+- `hover` now dispatches the pointer-event family (`pointerover`/`pointerenter`/`pointermove`) alongside the mouse events in real pointer order, so Pointer Events handlers such as React's `onPointerEnter` run; accepts `x`/`y` coordinates like `click`; and reports that synthetic events never apply CSS `:hover`.
+- `drag` now moves along an interpolated pointer-event path with dwell instead of jumping from source to target, so distance-threshold drag libraries (e.g. dnd-kit's `PointerSensor`) start a drag; it fails with `input_not_applied` when the gesture produced no DOM change instead of reporting a silent no-op.
 - `type_text` now inserts into model-backed editors (ProseMirror, Lexical, Slate) by driving `document.execCommand("insertText")`, falling back to `beforeinput`/`input` events carrying `inputType` and `data`, instead of a direct DOM mutation with a bare `input` event those editors discard on the next render.
 - `type_text` now fails with `input_not_applied` when non-empty text left the target unchanged, instead of reporting success.
 - Fixed native typing (`native: true`) always failing with `native_input_focus_lost` while Safari was frontmost: the frontmost check now reads activation state fresh on every call instead of an NSWorkspace value cached at first touch, and runs once before and once after typing instead of per keystroke, and the tool description no longer claims native input foregrounds Safari.

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -24,6 +24,11 @@
         return error;
     }
 
+    function pointerEvent(type, opts) {
+        const Ctor = typeof PointerEvent === "function" ? PointerEvent : MouseEvent;
+        return new Ctor(type, opts);
+    }
+
     // Escapes a value for use inside a quoted CSS attribute selector.
     function escapeCssString(value) {
         if (window.CSS && typeof window.CSS.escape === "function") {
@@ -782,7 +787,9 @@
                 cancelable: true,
             };
             el.dispatchEvent(new KeyboardEvent("keydown", keyOpts));
-            el.dispatchEvent(new KeyboardEvent("keypress", keyOpts));
+            if (firesKeypress(params.submitKey, keyOpts)) {
+                el.dispatchEvent(new KeyboardEvent("keypress", keyOpts));
+            }
             el.dispatchEvent(new KeyboardEvent("keyup", keyOpts));
 
             // For Enter, also submit the form if present
@@ -938,6 +945,12 @@
 
     // ─── Press Key ───────────────────────────────────────────────────
 
+    // UI Events: keypress fires only for character-producing keys (Enter maps
+    // to \r), and never for Ctrl/Meta combos.
+    function firesKeypress(key, opts) {
+        return (key.length === 1 || key === "Enter") && !opts.ctrlKey && !opts.metaKey;
+    }
+
     // KeyboardEvent.code is physical-key based: letters are KeyX, digits Digit0-9.
     function keyCode(key) {
         if (key.length !== 1) return key;
@@ -973,7 +986,9 @@
 
         const target = document.activeElement || document.body;
         target.dispatchEvent(new KeyboardEvent("keydown", eventOpts));
-        target.dispatchEvent(new KeyboardEvent("keypress", eventOpts));
+        if (firesKeypress(key, eventOpts)) {
+            target.dispatchEvent(new KeyboardEvent("keypress", eventOpts));
+        }
         target.dispatchEvent(new KeyboardEvent("keyup", eventOpts));
 
         return `Pressed ${keyString}`;
@@ -982,11 +997,24 @@
     // ─── Hover ───────────────────────────────────────────────────────
 
     function hoverElement(params) {
-        const el = resolveElement(params);
+        let el = null;
+        if (params.x !== undefined && params.y !== undefined) {
+            el = document.elementFromPoint(params.x, params.y);
+            if (!el) {
+                throw toolError(
+                    "target_not_found",
+                    `No element at coordinates (${params.x}, ${params.y})`,
+                    false,
+                    "take_snapshot"
+                );
+            }
+        } else {
+            el = resolveElement(params);
+        }
         if (!el) {
             throw toolError(
                 "invalid_input",
-                "hover requires uid, selector, or text",
+                "hover requires uid, selector, text, or x and y",
                 false,
                 "fix_input"
             );
@@ -1001,18 +1029,25 @@
             view: window,
             clientX: rect.left + rect.width / 2,
             clientY: rect.top + rect.height / 2,
+            button: 0,
+            buttons: 0,
         };
+        const pointerOpts = { ...eventOpts, pointerId: 1, pointerType: "mouse", isPrimary: true };
 
-        el.dispatchEvent(new MouseEvent("mouseenter", eventOpts));
+        // Real pointer order: pointer family first, over before enter.
+        el.dispatchEvent(pointerEvent("pointerover", pointerOpts));
+        el.dispatchEvent(pointerEvent("pointerenter", pointerOpts));
         el.dispatchEvent(new MouseEvent("mouseover", eventOpts));
+        el.dispatchEvent(new MouseEvent("mouseenter", eventOpts));
+        el.dispatchEvent(pointerEvent("pointermove", pointerOpts));
         el.dispatchEvent(new MouseEvent("mousemove", eventOpts));
 
-        return `Hovered over <${el.tagName.toLowerCase()}>`;
+        return `Hovered over <${el.tagName.toLowerCase()}> (synthetic events; CSS :hover is not applied)`;
     }
 
     // ─── Drag ────────────────────────────────────────────────────────
 
-    function dragElement(params) {
+    async function dragElement(params) {
         const fromEl = resolveElement({
             uid: params.fromUid,
             selector: params.fromSelector,
@@ -1041,24 +1076,57 @@
         const toY = toRect.top + toRect.height / 2;
 
         const baseOpts = { bubbles: true, cancelable: true, view: window };
+        const pointerBase = { ...baseOpts, pointerId: 1, pointerType: "mouse", isPrimary: true };
 
-        // Start drag
-        fromEl.dispatchEvent(new MouseEvent("mousedown", { ...baseOpts, clientX: fromX, clientY: fromY }));
-        fromEl.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: fromX, clientY: fromY }));
+        let mutated = false;
+        const observer = new MutationObserver((records) => {
+            if (records.length > 0) mutated = true;
+        });
+        observer.observe(document.body || document.documentElement, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            characterData: true,
+        });
 
-        // Create and dispatch dragstart
+        fromEl.dispatchEvent(pointerEvent("pointerdown", { ...pointerBase, clientX: fromX, clientY: fromY, button: 0, buttons: 1 }));
+        fromEl.dispatchEvent(new MouseEvent("mousedown", { ...baseOpts, clientX: fromX, clientY: fromY, button: 0, buttons: 1 }));
+
+        // Distance-threshold drag libraries (dnd-kit PointerSensor) only start
+        // a drag after real movement; a single jump at the source never begins one.
         const dataTransfer = new DataTransfer();
-        fromEl.dispatchEvent(new DragEvent("dragstart", { ...baseOpts, clientX: fromX, clientY: fromY, dataTransfer }));
+        const steps = 8;
+        for (let i = 1; i <= steps; i++) {
+            const x = fromX + ((toX - fromX) * i) / steps;
+            const y = fromY + ((toY - fromY) * i) / steps;
+            fromEl.dispatchEvent(pointerEvent("pointermove", { ...pointerBase, clientX: x, clientY: y, button: 0, buttons: 1 }));
+            fromEl.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: x, clientY: y, button: 0, buttons: 1 }));
+            if (i === 1) {
+                fromEl.dispatchEvent(new DragEvent("dragstart", { ...baseOpts, clientX: fromX, clientY: fromY, dataTransfer }));
+            }
+            await new Promise((resolve) => setTimeout(resolve, 25));
+        }
 
-        // Move to target
         toEl.dispatchEvent(new DragEvent("dragenter", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
         toEl.dispatchEvent(new DragEvent("dragover", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
-
-        // Drop
         toEl.dispatchEvent(new DragEvent("drop", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
+        toEl.dispatchEvent(pointerEvent("pointerup", { ...pointerBase, clientX: toX, clientY: toY, button: 0, buttons: 0 }));
+        toEl.dispatchEvent(new MouseEvent("mouseup", { ...baseOpts, clientX: toX, clientY: toY, button: 0, buttons: 0 }));
         fromEl.dispatchEvent(new DragEvent("dragend", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
 
-        fromEl.dispatchEvent(new MouseEvent("mouseup", { ...baseOpts, clientX: toX, clientY: toY }));
+        // A gesture nothing reacted to is a silent no-op: give the page a
+        // frame to respond, then fail rather than claim a drag that never started.
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        const pending = observer.takeRecords();
+        observer.disconnect();
+        if (!mutated && pending.length === 0) {
+            throw toolError(
+                "input_not_applied",
+                `Drag from <${fromEl.tagName.toLowerCase()}> to <${toEl.tagName.toLowerCase()}> produced no DOM change; the page may not have recognized the synthetic gesture`,
+                false,
+                "use_native_input"
+            );
+        }
 
         return `Dragged <${fromEl.tagName.toLowerCase()}> to <${toEl.tagName.toLowerCase()}>`;
     }

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -1089,36 +1089,43 @@
             characterData: true,
         });
 
-        fromEl.dispatchEvent(pointerEvent("pointerdown", { ...pointerBase, clientX: fromX, clientY: fromY, button: 0, buttons: 1 }));
-        fromEl.dispatchEvent(new MouseEvent("mousedown", { ...baseOpts, clientX: fromX, clientY: fromY, button: 0, buttons: 1 }));
+        // The observer watches the whole document, so it has to come back off
+        // again on every exit path, not just the expected one.
+        let pending = [];
+        try {
+            fromEl.dispatchEvent(pointerEvent("pointerdown", { ...pointerBase, clientX: fromX, clientY: fromY, button: 0, buttons: 1 }));
+            fromEl.dispatchEvent(new MouseEvent("mousedown", { ...baseOpts, clientX: fromX, clientY: fromY, button: 0, buttons: 1 }));
 
-        // Distance-threshold drag libraries (dnd-kit PointerSensor) only start
-        // a drag after real movement; a single jump at the source never begins one.
-        const dataTransfer = new DataTransfer();
-        const steps = 8;
-        for (let i = 1; i <= steps; i++) {
-            const x = fromX + ((toX - fromX) * i) / steps;
-            const y = fromY + ((toY - fromY) * i) / steps;
-            fromEl.dispatchEvent(pointerEvent("pointermove", { ...pointerBase, clientX: x, clientY: y, button: 0, buttons: 1 }));
-            fromEl.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: x, clientY: y, button: 0, buttons: 1 }));
-            if (i === 1) {
-                fromEl.dispatchEvent(new DragEvent("dragstart", { ...baseOpts, clientX: fromX, clientY: fromY, dataTransfer }));
+            // Distance-threshold drag libraries (dnd-kit PointerSensor) only start
+            // a drag after real movement; a single jump at the source never begins one.
+            const dataTransfer = new DataTransfer();
+            const steps = 8;
+            for (let i = 1; i <= steps; i++) {
+                const x = fromX + ((toX - fromX) * i) / steps;
+                const y = fromY + ((toY - fromY) * i) / steps;
+                fromEl.dispatchEvent(pointerEvent("pointermove", { ...pointerBase, clientX: x, clientY: y, button: 0, buttons: 1 }));
+                fromEl.dispatchEvent(new MouseEvent("mousemove", { ...baseOpts, clientX: x, clientY: y, button: 0, buttons: 1 }));
+                if (i === 1) {
+                    fromEl.dispatchEvent(new DragEvent("dragstart", { ...baseOpts, clientX: fromX, clientY: fromY, dataTransfer }));
+                }
+                await new Promise((resolve) => setTimeout(resolve, 25));
             }
-            await new Promise((resolve) => setTimeout(resolve, 25));
+
+            toEl.dispatchEvent(new DragEvent("dragenter", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
+            toEl.dispatchEvent(new DragEvent("dragover", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
+            toEl.dispatchEvent(new DragEvent("drop", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
+            toEl.dispatchEvent(pointerEvent("pointerup", { ...pointerBase, clientX: toX, clientY: toY, button: 0, buttons: 0 }));
+            toEl.dispatchEvent(new MouseEvent("mouseup", { ...baseOpts, clientX: toX, clientY: toY, button: 0, buttons: 0 }));
+            fromEl.dispatchEvent(new DragEvent("dragend", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
+
+            // A gesture nothing reacted to is a silent no-op: give the page a
+            // frame to respond, then fail rather than claim a drag that never started.
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            pending = observer.takeRecords();
+        } finally {
+            observer.disconnect();
         }
 
-        toEl.dispatchEvent(new DragEvent("dragenter", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
-        toEl.dispatchEvent(new DragEvent("dragover", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
-        toEl.dispatchEvent(new DragEvent("drop", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
-        toEl.dispatchEvent(pointerEvent("pointerup", { ...pointerBase, clientX: toX, clientY: toY, button: 0, buttons: 0 }));
-        toEl.dispatchEvent(new MouseEvent("mouseup", { ...baseOpts, clientX: toX, clientY: toY, button: 0, buttons: 0 }));
-        fromEl.dispatchEvent(new DragEvent("dragend", { ...baseOpts, clientX: toX, clientY: toY, dataTransfer }));
-
-        // A gesture nothing reacted to is a silent no-op: give the page a
-        // frame to respond, then fail rather than claim a drag that never started.
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        const pending = observer.takeRecords();
-        observer.disconnect();
         if (!mutated && pending.length === 0) {
             throw toolError(
                 "input_not_applied",

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -391,18 +391,20 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "hover",
-                description: "Hover element to trigger tooltips/menus.",
+                description: "Hover element to trigger tooltips/menus. Dispatches pointer and mouse events; synthetic events never apply CSS :hover.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
                         "uid": Self.uid, "selector": Self.sel, "text": Self.txt,
+                        "x": .object(["type": .string("number")]),
+                        "y": .object(["type": .string("number")]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
                     ])),
                 ])
             ),
             Tool(
                 name: "drag",
-                description: "Drag and drop between elements.",
+                description: "Drag and drop between elements along an interpolated pointer-event path plus HTML5 drag events.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([

--- a/README.md
+++ b/README.md
@@ -260,12 +260,12 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 | `select_option` | Select a dropdown option by value or label |
 | `scroll` | Scroll page or element in any direction |
 | `press_key` | Press key combinations (e.g., `Enter`, `Meta+a`, `Control+c`) |
-| `hover` | Hover to trigger tooltips, menus, or hover states |
-| `drag` | Drag and drop between elements |
+| `hover` | Hover to trigger tooltips, menus, or hover handlers (pointer + mouse events) |
+| `drag` | Drag and drop between elements along an interpolated pointer path |
 | `upload_file` | Attach local files to an `<input type="file">` |
 | `drop_file` | Drop local files onto an element |
 
-> **Note:** Interaction tools drive elements via synthetic DOM events (and React-compatible value setting for text), which works across the vast majority of sites. Because the events are synthetic, `press_key` modifier combos (e.g. `Meta+a`, `Control+c`) and `drag` reach page-level JS handlers but do **not** trigger native browser actions — clipboard copy/paste, select-all, or HTML5 native drag-and-drop. Use `type_text`/`form_input` for text entry and `javascript_tool` when a true native action is required.
+> **Note:** Interaction tools drive elements via synthetic DOM events (and React-compatible value setting for text), which works across the vast majority of sites. Because the events are synthetic, `press_key` modifier combos (e.g. `Meta+a`, `Control+c`) and `drag` reach page-level JS handlers but do **not** trigger native browser actions — clipboard copy/paste, select-all, or HTML5 native drag-and-drop. Synthetic events also never apply CSS `:hover`, so `hover` can verify hover *handlers* (including `onPointerEnter`) but not hover *styling*. Use `type_text`/`form_input` for text entry and `javascript_tool` when a true native action is required.
 
 ### Dialogs
 

--- a/Tests/content-input-fidelity.test.mjs
+++ b/Tests/content-input-fidelity.test.mjs
@@ -1,0 +1,320 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+// Minimal DOM stand-ins, same shape as content-tool-safety.test.mjs, plus the
+// event constructors and MutationObserver the input handlers use.
+function text(value) {
+    return { nodeType: TEXT_NODE, textContent: value };
+}
+
+function el(tag, options = {}, children = []) {
+    const node = {
+        nodeType: ELEMENT_NODE,
+        tagName: tag.toUpperCase(),
+        attributes: options.attributes || {},
+        hidden: false,
+        id: options.id || "",
+        childNodes: children,
+        getAttribute(name) {
+            return name in this.attributes ? this.attributes[name] : null;
+        },
+        getBoundingClientRect: () => ({ left: 0, top: 0, x: 0, y: 0, width: 10, height: 10 }),
+        scrollIntoView() {},
+        focus() {},
+        dispatchEvent() { return true; },
+        ...options.extra,
+    };
+    Object.defineProperty(node, "children", {
+        get: () => node.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    if (!("textContent" in (options.extra || {}))) {
+        Object.defineProperty(node, "textContent", {
+            get: () => node.childNodes.map((c) => c.textContent).join(""),
+        });
+    }
+    return node;
+}
+
+class FakeDataTransfer {
+    constructor() {
+        this.items = [];
+    }
+}
+
+class FakeMutationObserver {
+    constructor(callback) {
+        this.callback = callback;
+        this.records = [];
+    }
+    observe() {
+        FakeMutationObserver.active = this;
+    }
+    disconnect() {
+        if (FakeMutationObserver.active === this) FakeMutationObserver.active = null;
+    }
+    takeRecords() {
+        // Mirror the real DOM: queued records are delivered to the callback,
+        // not held for takeRecords, so the handler must count callback deliveries.
+        const records = this.records;
+        this.records = [];
+        if (records.length > 0) this.callback(records);
+        return [];
+    }
+    // Test hook: simulate the page reacting to the synthetic gesture.
+    mutate(record = { type: "childList" }) {
+        this.records.push(record);
+    }
+}
+FakeMutationObserver.active = null;
+
+function loadContent(body, documentOverrides = {}, windowOverrides = {}) {
+    let listener;
+    const document = {
+        body,
+        documentElement: body,
+        activeElement: null,
+        getElementById: () => null,
+        querySelector: () => null,
+        querySelectorAll: () => [],
+        elementFromPoint: () => null,
+        execCommand: () => false,
+        createRange: () => ({ selectNodeContents() {}, collapse() {} }),
+        createTreeWalker(root, _show, filter) {
+            const queue = [];
+            const collect = (n) => { for (const c of n.children) { queue.push(c); collect(c); } };
+            collect(root);
+            return {
+                nextNode() {
+                    while (queue.length) {
+                        const n = queue.shift();
+                        if (filter.acceptNode(n) === 1) return n;
+                    }
+                    return null;
+                },
+            };
+        },
+        ...documentOverrides,
+    };
+
+    class FakeEvent {
+        constructor(type, options = {}) {
+            this.type = type;
+            Object.assign(this, options);
+        }
+    }
+
+    const scrolls = [];
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document,
+        Node: { ELEMENT_NODE, TEXT_NODE },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        Event: FakeEvent,
+        KeyboardEvent: FakeEvent,
+        MouseEvent: FakeEvent,
+        PointerEvent: FakeEvent,
+        DragEvent: FakeEvent,
+        InputEvent: FakeEvent,
+        DataTransfer: FakeDataTransfer,
+        MutationObserver: FakeMutationObserver,
+        HTMLInputElement: class {},
+        HTMLTextAreaElement: class {},
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            postMessage: () => {},
+            innerHeight: 800,
+            scrollBy: (options) => scrolls.push(options),
+            getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+            getSelection: () => ({
+                rangeCount: 0,
+                removeAllRanges() {},
+                addRange() {},
+                getRangeAt() { return null; },
+            }),
+            ...windowOverrides,
+        },
+    });
+
+    const call = (action, params) => new Promise((r) => listener({ action, params }, {}, r));
+    call.scrolls = scrolls;
+    return call;
+}
+
+function pressedKeys() {
+    const events = [];
+    const body = el("body", {}, []);
+    body.dispatchEvent = (event) => { events.push(event.type); return true; };
+    const call = loadContent(body, { activeElement: null, body });
+    return { events, call };
+}
+
+// ─── press_key keypress fidelity ─────────────────────────────────────
+
+test("press_key fires keypress only for character-producing keys", async () => {
+    const { events, call } = pressedKeys();
+
+    await call("press_key", { key: "a" });
+    await call("press_key", { key: "Escape" });
+    await call("press_key", { key: "ArrowDown" });
+    await call("press_key", { key: "Tab" });
+
+    assert.deepEqual(events, [
+        "keydown", "keypress", "keyup",
+        "keydown", "keyup",
+        "keydown", "keyup",
+        "keydown", "keyup",
+    ]);
+});
+
+test("press_key keeps keypress for Enter but drops it for Ctrl/Meta combos", async () => {
+    const { events, call } = pressedKeys();
+
+    await call("press_key", { key: "Enter" });
+    await call("press_key", { key: "Control+a" });
+    await call("press_key", { key: "Meta+c" });
+
+    assert.deepEqual(events, [
+        "keydown", "keypress", "keyup",
+        "keydown", "keyup",
+        "keydown", "keyup",
+    ]);
+});
+
+test("type_text submitKey follows the same keypress rule", async () => {
+    const events = [];
+    const field = el("input", {
+        id: "a",
+        extra: {
+            type: "text",
+            value: "",
+            dispatchEvent(event) { events.push(event.type); return true; },
+        },
+    });
+    const call = loadContent(el("body", {}, [field]), { querySelector: () => field });
+
+    await call("type_text", { selector: "#a", text: "x", submitKey: "Tab" });
+    assert.deepEqual(events.slice(-2), ["keydown", "keyup"]);
+
+    events.length = 0;
+    await call("type_text", { selector: "#a", text: "x", submitKey: "Enter" });
+    assert.deepEqual(events.slice(-3), ["keydown", "keypress", "keyup"]);
+});
+
+// ─── hover pointer events and parity ─────────────────────────────────
+
+test("hover dispatches pointer and mouse families in real pointer order", async () => {
+    const events = [];
+    const target = el("a", {
+        id: "t",
+        extra: { dispatchEvent(event) { events.push(event); return true; } },
+    });
+    const call = loadContent(el("body", {}, [target]), { querySelector: () => target });
+
+    const response = await call("hover", { selector: "#t" });
+
+    assert.equal(response.error, null);
+    assert.deepEqual(events.map((e) => e.type), [
+        "pointerover", "pointerenter", "mouseover", "mouseenter", "pointermove", "mousemove",
+    ]);
+    assert.equal(events[0].pointerType, "mouse");
+    assert.match(response.data, /CSS :hover is not applied/);
+});
+
+test("hover accepts x and y like click", async () => {
+    const events = [];
+    const target = el("div", {
+        extra: { dispatchEvent(event) { events.push(event.type); return true; } },
+    });
+    const call = loadContent(el("body", {}, [target]), { elementFromPoint: () => target });
+
+    const response = await call("hover", { x: 10, y: 20 });
+
+    assert.equal(response.error, null);
+    assert.ok(events.length > 0, "the element at the point received the hover");
+
+    const missing = await loadContent(el("body", {}, []))("hover", { x: 10, y: 20 });
+    assert.equal(missing.errorCode, "target_not_found");
+});
+
+// ─── drag pointer path and no-op detection ───────────────────────────
+
+function dragHarness() {
+    const fromEvents = [];
+    const toEvents = [];
+    const fromEl = el("div", {
+        id: "from",
+        extra: {
+            getBoundingClientRect: () => ({ left: 0, top: 0, x: 0, y: 0, width: 10, height: 10 }),
+            dispatchEvent(event) { fromEvents.push(event); return true; },
+        },
+    });
+    const toEl = el("div", {
+        id: "to",
+        extra: {
+            getBoundingClientRect: () => ({ left: 100, top: 100, x: 100, y: 100, width: 10, height: 10 }),
+            dispatchEvent(event) { toEvents.push(event); return true; },
+        },
+    });
+    const call = loadContent(el("body", {}, [fromEl, toEl]), {
+        querySelector: (selector) => (selector === "#from" ? fromEl : toEl),
+    });
+    return { fromEvents, toEvents, call };
+}
+
+test("drag moves along an interpolated pointer path and completes at the target", async () => {
+    const { fromEvents, toEvents, call } = dragHarness();
+    const done = call("drag", { fromSelector: "#from", toSelector: "#to" });
+    // The page reacts mid-gesture, as a drag library mounting an overlay would.
+    setTimeout(() => FakeMutationObserver.active?.mutate(), 100);
+
+    const response = await done;
+
+    assert.equal(response.error, null);
+    assert.equal(response.data, "Dragged <div> to <div>");
+
+    const types = fromEvents.map((e) => e.type);
+    assert.equal(types[0], "pointerdown");
+    assert.equal(types[1], "mousedown");
+    assert.ok(types.includes("dragstart"), "HTML5 dragstart still fires for native draggable handlers");
+    assert.equal(types.at(-1), "dragend");
+
+    const moves = fromEvents.filter((e) => e.type === "pointermove");
+    assert.ok(moves.length >= 8, "the pointer path is interpolated, not a single jump");
+    assert.ok(moves.every((e) => e.buttons === 1), "moves carry the pressed button");
+    const xs = moves.map((e) => e.clientX);
+    assert.ok(xs.every((x, i) => i === 0 || x > xs[i - 1]), "moves advance toward the target");
+    const last = moves.at(-1);
+    assert.equal(last.clientX, 105);
+    assert.equal(last.clientY, 105);
+
+    const toTypes = toEvents.map((e) => e.type);
+    assert.deepEqual(toTypes.slice(0, 3), ["dragenter", "dragover", "drop"]);
+    assert.ok(toTypes.includes("pointerup"), "pointer-sensor libraries see the gesture end");
+    const up = toEvents.find((e) => e.type === "pointerup");
+    assert.equal(up.clientX, 105);
+    assert.equal(up.buttons, 0);
+});
+
+test("drag fails with input_not_applied when nothing reacts to the gesture", async () => {
+    const { call } = dragHarness();
+
+    const response = await call("drag", { fromSelector: "#from", toSelector: "#to" });
+
+    assert.equal(response.errorCode, "input_not_applied");
+    assert.equal(response.recoveryAction, "use_native_input");
+    assert.match(response.error, /no DOM change/);
+});

--- a/Tests/content-input-fidelity.test.mjs
+++ b/Tests/content-input-fidelity.test.mjs
@@ -252,14 +252,18 @@ test("hover accepts x and y like click", async () => {
 
 // ─── drag pointer path and no-op detection ───────────────────────────
 
-function dragHarness() {
+function dragHarness({ throwOn } = {}) {
     const fromEvents = [];
     const toEvents = [];
     const fromEl = el("div", {
         id: "from",
         extra: {
             getBoundingClientRect: () => ({ left: 0, top: 0, x: 0, y: 0, width: 10, height: 10 }),
-            dispatchEvent(event) { fromEvents.push(event); return true; },
+            dispatchEvent(event) {
+                if (event.type === throwOn) throw new Error(`dispatch failed on ${event.type}`);
+                fromEvents.push(event);
+                return true;
+            },
         },
     });
     const toEl = el("div", {
@@ -317,4 +321,15 @@ test("drag fails with input_not_applied when nothing reacts to the gesture", asy
     assert.equal(response.errorCode, "input_not_applied");
     assert.equal(response.recoveryAction, "use_native_input");
     assert.match(response.error, /no DOM change/);
+});
+
+test("drag disconnects its observer even when the gesture throws partway", async () => {
+    // The observer watches the whole document with subtree, attributes, and
+    // characterData; leaking one would keep firing for the life of the page.
+    const { call } = dragHarness({ throwOn: "dragstart" });
+
+    const response = await call("drag", { fromSelector: "#from", toSelector: "#to" });
+
+    assert.match(response.error, /dispatch failed on dragstart/);
+    assert.equal(FakeMutationObserver.active, null, "the observer is disconnected on the throwing path");
 });


### PR DESCRIPTION
## Problem

Three measured synthetic-input gaps, all in `content.js`:

- `press_key` fires `keypress` for Escape, Tab, and arrows — UI Events fires it only for character-producing keys, so pages reading `keypress` as "a character was typed" get phantom input on every dismiss/navigation key.
- `hover` sends no pointer events, only mouse events — React `onPointerEnter` never runs while the tool reports `Hovered over <a>`.
- `drag` moves zero distance (`mousedown` and `mousemove` both at the source center), so distance-threshold libraries like dnd-kit's `PointerSensor` never start a drag — and the tool still reports success.

## Fix

- `keypress` only for single characters and Enter, never with Ctrl/Meta (also `type_text`'s `submitKey`).
- `hover` dispatches the pointer-event family in real pointer order, takes `x`/`y` like `click`, and states that CSS `:hover` is never applied.
- `drag` walks an interpolated pointer path (8 steps, 25 ms dwell), keeps the HTML5 drag events, and fails `input_not_applied` when nothing reacts (#37 no-op class).

## Validation

- `node --test`: 65/65 (7 new); `swift test`: 31/31.
- Live Safari gate (vite + React 19 + `@dnd-kit/core` 6.3.1): keypress readback per spec for Escape/ArrowDown/`a`/Enter/Ctrl+a; `onPointerEnter` fired and mounted its preview; dnd-kit `Distance(8)` drag completed A→B; listener-free drag errors.

Native CGEvent key/drag/hover paths are a separate planned PR; this is the synthetic half.
