### PR TITLE
fix: move auth tokens out of ~/.config so a symlinked config dir still connects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Auth tokens are now written to `~/Library/Application Support/MCPSafari/tokens/<port>` in addition to the previous `~/.config/mcp-safari/tokens/<port>`, and the extension prefers the new location. A `~/.config` symlinked into a dotfiles repo resolves outside the sandboxed extension's read grant, which left the extension permanently disconnected with no diagnostic.
+- `mcp-safari doctor` reports a new `token_path` check that warns when the token directory resolves somewhere other than its literal path, and now names the token file path it checked.
+
 ### Security
 - `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
 

--- a/MCPSafari/MCPSafari Extension/MCPSafari Extension.entitlements
+++ b/MCPSafari/MCPSafari Extension/MCPSafari Extension.entitlements
@@ -6,6 +6,7 @@
 	<true/>
 	<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
 	<array>
+		<string>/Library/Application Support/MCPSafari/</string>
 		<string>/.config/mcp-safari/</string>
 	</array>
 	<key>com.apple.security.files.user-selected.read-only</key>

--- a/MCPSafari/MCPSafari Extension/SafariWebExtensionHandler.swift
+++ b/MCPSafari/MCPSafari Extension/SafariWebExtensionHandler.swift
@@ -88,20 +88,30 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
         return TokenLoadResult(tokens: [:], legacyToken: nil, checkedPaths: checkedPaths)
     }
 
+    /// Token roots to search, most preferred first.
+    ///
+    /// Application Support comes first: this extension is sandboxed, and its
+    /// read exception is evaluated against the *resolved* path, so a `~/.config`
+    /// symlinked into a dotfiles repo puts the token outside the granted path
+    /// and makes it unreadable. `~/.config/mcp-safari` stays in the list so a
+    /// server predating the move still authenticates.
+    private static let tokenRootRelativePaths = [
+        "Library/Application Support/MCPSafari",
+        ".config/mcp-safari",
+    ]
+
     private static func tokenConfigDirectories() -> [URL] {
         var directories: [URL] = []
 
-        if let realHomeDirectory {
+        for relativePath in tokenRootRelativePaths {
+            if let realHomeDirectory {
+                appendUnique(realHomeDirectory.appendingPathComponent(relativePath), to: &directories)
+            }
             appendUnique(
-                realHomeDirectory.appendingPathComponent(".config/mcp-safari"),
+                FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(relativePath),
                 to: &directories
             )
         }
-
-        appendUnique(
-            FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".config/mcp-safari"),
-            to: &directories
-        )
 
         return directories
     }

--- a/MCPServer/Sources/mcp-safari/Diagnostics.swift
+++ b/MCPServer/Sources/mcp-safari/Diagnostics.swift
@@ -191,18 +191,20 @@ enum Doctor {
                 code: "token_file",
                 status: permissions == 0o600 ? .ok : .warning,
                 message: permissions == 0o600
-                    ? "Authentication token file exists with mode 0600 for port \(port)."
-                    : "Authentication token file exists for port \(port), but its permissions are not 0600.",
+                    ? "Authentication token file exists with mode 0600 at \(tokenURL.path)."
+                    : "Authentication token file exists at \(tokenURL.path), but its permissions are not 0600.",
                 recovery: permissions == 0o600 ? nil : "Restart mcp-safari to recreate the token file securely."
             ))
         } else {
             checks.append(.init(
                 code: "token_file",
                 status: .warning,
-                message: "No authentication token file exists for port \(port).",
+                message: "No authentication token file exists at \(tokenURL.path).",
                 recovery: "Start an MCP client configured to run mcp-safari."
             ))
         }
+
+        checks.append(tokenPathCheck(for: paths.tokenDirectoryURL))
 
         let overall: DiagnosticStatus = checks.contains { $0.status == .error }
             ? .error
@@ -255,6 +257,35 @@ enum Doctor {
             }
         }
         return lines.joined(separator: "\n")
+    }
+
+    /// The extension reads tokens through a sandbox exception granted on a
+    /// literal home-relative path, which the sandbox evaluates against the
+    /// resolved path. A symlink anywhere in the token directory puts the real
+    /// file outside that grant: the server writes it, the extension cannot read
+    /// it, and nothing else in the system reports why.
+    static func tokenPathCheck(for tokenDirectoryURL: URL) -> DiagnosticCheck {
+        let literal = tokenDirectoryURL.standardizedFileURL.path
+        let resolved = tokenDirectoryURL.resolvingSymlinksInPath().standardizedFileURL.path
+
+        guard literal != resolved else {
+            return .init(
+                code: "token_path",
+                status: .ok,
+                message: "Token directory is a real path the extension sandbox can read.",
+                recovery: nil
+            )
+        }
+
+        return .init(
+            code: "token_path",
+            status: .warning,
+            message: "Token directory \(literal) resolves to \(resolved). "
+                + "The Safari extension is sandboxed and can only read the unresolved path, "
+                + "so it will not find the token and will stay disconnected.",
+            recovery: "Replace the symlink with a real directory, "
+                + "or symlink the sibling directories you manage instead of the parent."
+        )
     }
 
     private static func check(

--- a/MCPServer/Sources/mcp-safari/WebSocketBridge.swift
+++ b/MCPServer/Sources/mcp-safari/WebSocketBridge.swift
@@ -152,20 +152,38 @@ actor WebSocketBridge {
 
     /// Authentication token that the extension must send as its first message.
     let authToken: String
-    /// Directory where per-port auth tokens are written for the extension to read.
-    static let tokenDirectoryURL: URL = {
+    /// Primary token root. The sandboxed extension reads tokens through a
+    /// home-relative-path exception that the sandbox evaluates against the
+    /// *resolved* path, and `~/.config` is commonly symlinked into a dotfiles
+    /// repo — which puts the real file outside the granted path and makes it
+    /// unreadable. `~/Library/Application Support` is effectively never
+    /// symlinked, so tokens live there.
+    static let applicationSupportDirectoryURL: URL = {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Application Support")
+            .appendingPathComponent("MCPSafari")
+    }()
+
+    /// Legacy token root, still written so extension builds that predate the
+    /// move keep authenticating.
+    static let configDirectoryURL: URL = {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config")
             .appendingPathComponent("mcp-safari")
-            .appendingPathComponent("tokens")
     }()
+
+    /// Token roots to populate, most preferred first.
+    static let tokenRootURLs: [URL] = [applicationSupportDirectoryURL, configDirectoryURL]
+
+    /// Directory where per-port auth tokens are written for the extension to read.
+    static let tokenDirectoryURL: URL = applicationSupportDirectoryURL
+        .appendingPathComponent("tokens")
+
     /// Legacy single-token path kept for older extension builds.
-    static let legacyTokenFilePath: String = {
-        tokenDirectoryURL
-            .deletingLastPathComponent()
-            .appendingPathComponent("token")
-            .path
-    }()
+    static let legacyTokenFilePath: String = configDirectoryURL
+        .appendingPathComponent("token")
+        .path
 
     static func tokenFilePath(for port: UInt16) -> String {
         tokenDirectoryURL.appendingPathComponent(String(port)).path
@@ -279,33 +297,33 @@ actor WebSocketBridge {
     }
 
     private func writeAuthTokenFile(for port: UInt16) throws {
+        // The preferred root must succeed; the legacy root is best effort so a
+        // broken or unwritable `~/.config` cannot stop the server from starting.
+        try writeToken(for: port, under: Self.applicationSupportDirectoryURL)
+        do {
+            try writeToken(for: port, under: Self.configDirectoryURL)
+        } catch {
+            logger.debug("Could not write legacy token under \(Self.configDirectoryURL.path): \(error)")
+        }
+    }
+
+    private func writeToken(for port: UInt16, under root: URL) throws {
         let fileManager = FileManager.default
-        let configDirectory = Self.tokenDirectoryURL.deletingLastPathComponent()
+        let tokenDirectory = root.appendingPathComponent("tokens")
 
-        try fileManager.createDirectory(at: Self.tokenDirectoryURL, withIntermediateDirectories: true)
-        try fileManager.setAttributes(
-            [.posixPermissions: 0o700],
-            ofItemAtPath: configDirectory.path
-        )
-        try fileManager.setAttributes(
-            [.posixPermissions: 0o700],
-            ofItemAtPath: Self.tokenDirectoryURL.path
-        )
+        try fileManager.createDirectory(at: tokenDirectory, withIntermediateDirectories: true)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: tokenDirectory.path)
 
-        let tokenFilePath = Self.tokenFilePath(for: port)
+        let tokenFilePath = tokenDirectory.appendingPathComponent(String(port)).path
         try authToken.write(toFile: tokenFilePath, atomically: true, encoding: .utf8)
-        try fileManager.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: tokenFilePath
-        )
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: tokenFilePath)
 
-        // Keep the legacy path populated for older extension builds. Current
-        // builds prefer the per-port token map and avoid this single-token race.
-        try authToken.write(toFile: Self.legacyTokenFilePath, atomically: true, encoding: .utf8)
-        try fileManager.setAttributes(
-            [.posixPermissions: 0o600],
-            ofItemAtPath: Self.legacyTokenFilePath
-        )
+        // Keep the single-token path populated for older extension builds.
+        // Current builds prefer the per-port map and avoid its rewrite race.
+        let singleTokenPath = root.appendingPathComponent("token").path
+        try authToken.write(toFile: singleTokenPath, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: singleTokenPath)
     }
 
     func start() async {

--- a/MCPServer/Tests/MCPSafariTests/TokenDirectoryTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/TokenDirectoryTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import MCPSafari
+
+struct TokenDirectoryTests {
+    /// The extension's sandbox exception is granted on the literal home-relative
+    /// path, so a symlinked token root leaves the token unreadable to it. The
+    /// server writes it either way, which is why this needs to be diagnosable.
+    @Test func doctorFlagsATokenDirectoryThatResolvesElsewhere() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let real = root.appendingPathComponent("dotfiles-repo/mcp-safari/tokens")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        let link = root.appendingPathComponent("linked-tokens")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+        let symlinked = Doctor.tokenPathCheck(for: link)
+        #expect(symlinked.status == .warning)
+        #expect(symlinked.code == "token_path")
+        #expect(symlinked.message.contains(real.standardizedFileURL.path))
+        #expect(symlinked.recovery != nil)
+
+        let direct = Doctor.tokenPathCheck(for: real)
+        #expect(direct.status == .ok)
+        #expect(direct.recovery == nil)
+    }
+
+    /// A symlinked token root is a warning, not a hard failure: the server still
+    /// runs, and an older extension reading the legacy root may still connect.
+    @Test func aSymlinkedTokenDirectoryDoesNotFailTheWholeReport() throws {
+        let root = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let executable = root.appendingPathComponent("mcp-safari")
+        try Data().write(to: executable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let real = root.appendingPathComponent("real-tokens")
+        try FileManager.default.createDirectory(at: real, withIntermediateDirectories: true)
+        let token = real.appendingPathComponent("8089")
+        try "token".write(to: token, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: token.path)
+        let link = root.appendingPathComponent("linked-tokens")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: real)
+
+        let report = Doctor.inspect(
+            paths: .init(
+                executableURL: executable,
+                appURL: root.appendingPathComponent("absent.app"),
+                tokenDirectoryURL: link
+            ),
+            extensionRegistered: true
+        )
+
+        let tokenPath = try #require(report.checks.first { $0.code == "token_path" })
+        #expect(tokenPath.status == .warning)
+        // The token itself is readable through the link from an unsandboxed
+        // process, so that check passes while the path check does not.
+        #expect(report.checks.first { $0.code == "token_file" }?.status == .ok)
+    }
+
+    /// Application Support is preferred precisely because `~/.config` is the
+    /// path users symlink into dotfiles repos.
+    @Test func applicationSupportIsThePreferredTokenRoot() {
+        #expect(WebSocketBridge.tokenRootURLs.first == WebSocketBridge.applicationSupportDirectoryURL)
+        #expect(WebSocketBridge.tokenRootURLs.contains(WebSocketBridge.configDirectoryURL))
+        #expect(
+            WebSocketBridge.tokenDirectoryURL
+                == WebSocketBridge.applicationSupportDirectoryURL.appendingPathComponent("tokens")
+        )
+        #expect(WebSocketBridge.tokenDirectoryURL.path.contains("Library/Application Support/MCPSafari"))
+        #expect(!WebSocketBridge.tokenDirectoryURL.path.contains(".config"))
+    }
+
+    /// Both roots stay populated so an extension build predating the move keeps
+    /// authenticating against a newer server.
+    @Test func theLegacyRootIsStillTheConfigDirectory() {
+        #expect(WebSocketBridge.legacyTokenFilePath.hasSuffix(".config/mcp-safari/token"))
+        #expect(WebSocketBridge.configDirectoryURL.path.hasSuffix(".config/mcp-safari"))
+    }
+
+    private func makeDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+}

--- a/README.md
+++ b/README.md
@@ -425,7 +425,9 @@ A minimal macOS app (`AppDelegate.swift`, `ViewController.swift`) that registers
 
 ### WebSocket Authentication
 
-The server generates a random UUID token at startup, writes it to `~/.config/mcp-safari/tokens/<port>` (mode `0600`), and requires it as the first WebSocket message before any MCP tool traffic is sent. The extension reads the per-port token map via native messaging from the host app, so multiple server instances can authenticate independently. Connections without a valid token are closed.
+The server generates a random UUID token at startup, writes it to `~/Library/Application Support/MCPSafari/tokens/<port>` (mode `0600`), and requires it as the first WebSocket message before any MCP tool traffic is sent. The extension reads the per-port token map via native messaging from the host app, so multiple server instances can authenticate independently. Connections without a valid token are closed.
+
+The token is also written to the previous location, `~/.config/mcp-safari/tokens/<port>`, so an extension build predating the move keeps authenticating. Application Support is preferred because the Safari extension is sandboxed: its read access is granted on a literal home-relative path, which the sandbox checks against the *resolved* path. A `~/.config` symlinked into a dotfiles repo therefore puts the token outside the granted path, and the extension silently never connects. `mcp-safari doctor` reports this as a `token_path` warning.
 
 ### Input Validation
 


### PR DESCRIPTION
Fixes #40.

## Problem

The Safari extension is sandboxed and reads the auth token through a static entitlement:

```xml
<key>com.apple.security.temporary-exception.files.home-relative-path.read-only</key>
<array><string>/.config/mcp-safari/</string></array>
```

The sandbox evaluates that grant against the **resolved** path. When `~/.config` is symlinked into a dotfiles repo — a common setup, and the reporter's — the token really lives at `~/code/dotfiles/.config/mcp-safari/tokens/<port>`, outside the grant. The server is unsandboxed so it writes the token happily; the extension simply can never read it. The visible symptom is an extension stuck at "disconnected" with nothing anywhere explaining why.

## Fix

Tokens move to `~/Library/Application Support/MCPSafari/tokens/<port>`, a path essentially nobody symlinks, and the extension searches there first.

`~/.config/mcp-safari` is still written and still searched, so an extension build predating this keeps authenticating against a newer server and vice versa. Writing the legacy root is now best effort — an unwritable or broken `~/.config` can no longer stop the server from starting.

**On making the path configurable,** which the issue asked about: I don't think it works, so I didn't. The sandbox exception is fixed in the signed entitlement at build time, so the readable set is decided before any flag exists. Pointing the server elsewhere at runtime would relocate the token somewhere the extension still can't read — the same failure, harder to diagnose.

**Why not an App Group,** the more canonical host-app↔extension channel: the writer here is a Homebrew-distributed unsandboxed CLI that ships independently of the app, not part of the app bundle. A group container path is team-ID prefixed, so the CLI would have to discover the team identifier at runtime and stay in sync with the app's provisioning. That's real coupling and fragility for no gain over Application Support, which both processes can name directly. An external unsandboxed writer also isn't what app groups are designed around.

## Diagnosability

The underlying trap — a token directory that resolves somewhere other than where it's named — was invisible to every tool we ship. `doctor` now reports it:

```
[ok]      token_path: Token directory is a real path the extension sandbox can read.
[warning] token_path: Token directory /Users/x/.config/mcp-safari/tokens resolves to
          /Users/x/code/dotfiles/.config/mcp-safari/tokens. The Safari extension is
          sandboxed and can only read the unresolved path, so it will not find the
          token and will stay disconnected.
```

It's a warning, not an error: the server still runs, and an older extension reading the legacy root may still connect. `token_file` now also names the path it checked rather than only the port.

## Validation

- `swift build`, `swift test` 35 (4 new), `node --test Tests/*.mjs` 58, `swift build -c release`
- Unsigned `xcodebuild` with the CI invocation, then `codesign -d --entitlements` on the built `.appex` to confirm both paths are embedded in that order
- Ran the release binary on a spare port and confirmed `~/Library/Application Support/MCPSafari/` and `tokens/` come out `0700`, the token file `0600`, and the legacy `~/.config/mcp-safari/tokens/<port>` still written `0600`
- `plutil -lint` on the entitlements, `git diff --check`

## Note for release

This only takes effect for users who install a new **app** build — the entitlement lives in the signed extension. A new CLI alone won't fix an affected install, since the extension is the side doing the read.
