### PR TITLE
feat: native press_key, hover, and drag via CGEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
 - `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
 - `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries whose byte counts are withheld are marked `timingRestricted: true`.
+- `press_key`, `hover`, and `drag` now accept `native: true` for real macOS events, the same opt-in `type_text` already had: keys that trigger default actions such as focus moves and dialog dismissal, a pointer path that produces true CSS `:hover` and boundary events, and drags that threshold-based libraries accept. Character keys resolve against the active keyboard layout, so `Meta+a` is Command-A on AZERTY rather than Command-Q.
 
 ### Bug Fixes
 - `read_network` with `clear` now removes only the entries the call returned, so a type- or URL-filtered clear no longer discards requests the caller never saw (matching `read_console`).

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -259,6 +259,14 @@ async function handleRequest(request) {
                 data = await handleNativeTypeText(params);
                 break;
 
+            case "native_press_key":
+                data = await handleNativePressKey(params);
+                break;
+
+            case "native_pointer":
+                data = await handleNativePointer(params);
+                break;
+
             // Page reading (delegated to content script)
             case "read_page":
             case "get_page_text":
@@ -408,17 +416,39 @@ async function handleSelectTab(params) {
     };
 }
 
-async function handleNativeTypeText(params) {
-    const tabId = params.tabId || (await getActiveTabId());
+async function focusTabForNativeInput(tabIdParam) {
+    const tabId = tabIdParam || (await getActiveTabId());
     const tab = await browser.tabs.get(tabId);
     await browser.tabs.update(tabId, { active: true });
     await browser.windows.update(tab.windowId, { focused: true });
     await delay(100);
+    return tabId;
+}
+
+async function handleNativeTypeText(params) {
+    const tabId = await focusTabForNativeInput(params.tabId);
     await sendToContentScript(tabId, {
         action: "prepare_native_input",
         params,
     });
     return "Safari is ready for native input";
+}
+
+async function handleNativePressKey(params) {
+    const tabId = await focusTabForNativeInput(params.tabId);
+    await sendToContentScript(tabId, {
+        action: "prepare_native_key",
+        params,
+    });
+    return "Safari is ready for native input";
+}
+
+async function handleNativePointer(params) {
+    const tabId = await focusTabForNativeInput(params.tabId);
+    return sendToContentScript(tabId, {
+        action: "native_pointer_points",
+        params,
+    });
 }
 
 function persistSelectedTab(tabId) {

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -130,6 +130,10 @@
                 return hoverElement(params);
             case "drag":
                 return dragElement(params);
+            case "native_pointer_points":
+                return nativePointerPoints(params);
+            case "prepare_native_key":
+                return prepareNativeKey(params);
             case "upload_file":
                 return uploadFile(params);
             case "drop_file":
@@ -1136,6 +1140,91 @@
         }
 
         return `Dragged <${fromEl.tagName.toLowerCase()}> to <${toEl.tagName.toLowerCase()}>`;
+    }
+
+    // ─── Native Pointer ──────────────────────────────────────────────
+
+    // CGEvent posts in global screen points. window.screenX/screenY use the
+    // same origin (top-left of the primary display, menu bar included).
+    // Safari's only side chrome is the left sidebar, so the full
+    // outerWidth-innerWidth difference sits on the left of the content area.
+    // Assumes 100% page zoom.
+    function nativePointerPoints(params) {
+        const toScreen = (cssX, cssY) => ({
+            x: window.screenX + (window.outerWidth - window.innerWidth) + cssX,
+            y: window.screenY + (window.outerHeight - window.innerHeight) + cssY,
+        });
+        const checked = (css) => {
+            if (!Number.isFinite(css.x) || !Number.isFinite(css.y)
+                || css.x < 0 || css.x >= window.innerWidth
+                || css.y < 0 || css.y >= window.innerHeight) {
+                throw toolError(
+                    "invalid_input",
+                    `Point (${Math.round(css.x)}, ${Math.round(css.y)}) is outside the viewport; native events at screen coordinates could hit another application`,
+                    false,
+                    "fix_input"
+                );
+            }
+            return toScreen(css.x, css.y);
+        };
+        const centerOf = (element) => {
+            const rect = element.getBoundingClientRect();
+            return checked({
+                x: rect.left + rect.width / 2,
+                y: rect.top + rect.height / 2,
+            });
+        };
+
+        const fromEl = params.fromUid || params.fromSelector
+            ? resolveElement({ uid: params.fromUid, selector: params.fromSelector })
+            : (params.uid || params.selector || params.text)
+                ? resolveElement(params)
+                : null;
+        const toEl = params.toUid || params.toSelector
+            ? resolveElement({ uid: params.toUid, selector: params.toSelector })
+            : null;
+
+        // Scroll only when an endpoint is off-viewport, before any
+        // measurement: scrolling shifts every rect, so measuring between two
+        // scrolls returns a stale point. A drag whose endpoints cannot share
+        // one scroll position fails the bounds check instead of dragging
+        // whatever happens to sit at the stale point.
+        const ensureVisible = (element) => {
+            const r = element.getBoundingClientRect();
+            const visible = r.top >= 0 && r.bottom <= window.innerHeight
+                && r.left >= 0 && r.right <= window.innerWidth;
+            if (!visible) element.scrollIntoView({ behavior: "instant", block: "center" });
+        };
+        if (fromEl) ensureVisible(fromEl);
+        if (toEl) ensureVisible(toEl);
+
+        let from;
+        if (fromEl) {
+            from = centerOf(fromEl);
+        } else if (params.x !== undefined && params.y !== undefined) {
+            from = checked({ x: Number(params.x), y: Number(params.y) });
+        } else {
+            throw toolError(
+                "invalid_input",
+                "native pointer requires uid, selector, text, or x/y",
+                false,
+                "fix_input"
+            );
+        }
+
+        const to = toEl ? centerOf(toEl) : undefined;
+        return to ? { from, to } : { from };
+    }
+
+    // A native key reaches whatever Safari has focused; when the chrome (e.g.
+    // the address bar) holds focus the page never sees it. Pull focus into
+    // the document unless the page already has it.
+    function prepareNativeKey() {
+        if (!document.hasFocus() && document.body) {
+            document.body.setAttribute("tabindex", "-1");
+            document.body.focus({ preventScroll: true });
+        }
+        return "Page ready for native key";
     }
 
     // ─── File Attachment ─────────────────────────────────────────────

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -379,11 +379,15 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "press_key",
-                description: "Press key combo (Enter, Tab, Meta+a, Control+c).",
+                description: "Press key combo (Enter, Tab, Meta+a, Control+c). Set native=true for a real macOS key event that triggers default actions (focus moves, dialog dismiss).",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
                         "key": .object(["type": .string("string")]),
+                        "native": .object([
+                            "type": .string("boolean"),
+                            "description": .string("Use a real macOS key event; requires Safari to already be the frontmost application and Accessibility permission"),
+                        ]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
                     ])),
                     "required": .array([.string("key")]),
@@ -391,20 +395,24 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "hover",
-                description: "Hover element to trigger tooltips/menus. Dispatches pointer and mouse events; synthetic events never apply CSS :hover.",
+                description: "Hover element to trigger tooltips/menus. Dispatches pointer and mouse events; synthetic events never apply CSS :hover. Set native=true to move the real OS pointer there, producing true :hover state and boundary events along the path.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
                         "uid": Self.uid, "selector": Self.sel, "text": Self.txt,
                         "x": .object(["type": .string("number")]),
                         "y": .object(["type": .string("number")]),
+                        "native": .object([
+                            "type": .string("boolean"),
+                            "description": .string("Move the real OS pointer; requires Safari to already be the frontmost application and Accessibility permission"),
+                        ]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
                     ])),
                 ])
             ),
             Tool(
                 name: "drag",
-                description: "Drag and drop between elements along an interpolated pointer-event path plus HTML5 drag events.",
+                description: "Drag and drop between elements along an interpolated pointer-event path plus HTML5 drag events. Set native=true for a real macOS mouse drag that threshold-based drag libraries (pointer sensors) accept.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
@@ -412,6 +420,10 @@ actor SafariMCPServer {
                         "toUid": .object(["type": .string("string")]),
                         "fromSelector": .object(["type": .string("string")]),
                         "toSelector": .object(["type": .string("string")]),
+                        "native": .object([
+                            "type": .string("boolean"),
+                            "description": .string("Use real macOS mouse events; requires Safari to already be the frontmost application and Accessibility permission"),
+                        ]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
                     ])),
                 ])
@@ -602,9 +614,9 @@ actor SafariMCPServer {
             case "form_input":      return try await handleFormInput(args)
             case "select_option":   return try await handleInteraction("select_option", args)
             case "scroll":          return try await handleInteraction("scroll", args)
-            case "press_key":       return try await handleInteraction("press_key", args)
-            case "hover":           return try await handleInteraction("hover", args)
-            case "drag":            return try await handleInteraction("drag", args)
+            case "press_key":       return try await handlePressKey(args)
+            case "hover":           return try await handleHover(args)
+            case "drag":            return try await handleDrag(args)
             case "upload_file":     return try await handleFileAction("upload_file", args)
             case "drop_file":       return try await handleFileAction("drop_file", args)
             case "handle_dialog":   return try await handleInteraction("handle_dialog", args)
@@ -905,14 +917,7 @@ actor SafariMCPServer {
 
         let submitKey = args["submitKey"]?.stringValue
         let submitKeyCode = try nativeSubmitKeyCode(for: submitKey)
-        guard AXIsProcessTrusted() else {
-            throw NativeInputError(failure: ToolFailure(
-                code: "native_input_permission_required",
-                message: "Native typing requires Accessibility permission for the app running mcp-safari (Codex, Claude, or your terminal). Enable that app in System Settings > Privacy & Security > Accessibility. Standard typing works without this permission.",
-                retryable: false,
-                recoveryAction: "grant_accessibility_to_mcp_client"
-            ))
-        }
+        try ensureNativeInputPermission()
 
         return NativeInputPlan(
             text: text,
@@ -922,18 +927,22 @@ actor SafariMCPServer {
         )
     }
 
+    private nonisolated static func checkNativeDeadline(_ deadline: Double?) throws {
+        guard let deadline, ProcessInfo.processInfo.systemUptime >= deadline else { return }
+        throw NativeInputError(failure: ToolFailure(
+            code: "batch_timeout",
+            message: "run_steps reached its deadline during native input. Input may be partial.",
+            retryable: false,
+            recoveryAction: "inspect_batch_result"
+        ))
+    }
+
     private nonisolated static func typeNativeText(
         _ input: NativeInputPlan,
         deadline: Double? = nil
     ) throws -> String {
         func checkDeadline() throws {
-            guard let deadline, ProcessInfo.processInfo.systemUptime >= deadline else { return }
-            throw NativeInputError(failure: ToolFailure(
-                code: "batch_timeout",
-                message: "run_steps reached its deadline during native typing. Input may be partial.",
-                retryable: false,
-                recoveryAction: "inspect_batch_result"
-            ))
+            try checkNativeDeadline(deadline)
         }
 
         try checkDeadline()
@@ -984,8 +993,8 @@ actor SafariMCPServer {
             throw NativeInputError(failure: ToolFailure(
                 code: "native_input_focus_lost",
                 message: afterTyping
-                    ? "Safari lost focus during native typing. Some keystrokes may have gone to another application; verify the target and retry."
-                    : "Safari is not the frontmost application. Native key events go to whichever app has focus; activate Safari and retry. Nothing was typed.",
+                    ? "Safari lost focus during native input. Some events may have gone to another application; verify the target and retry."
+                    : "Safari is not the frontmost application. Native events go to whichever app has focus; activate Safari and retry. Nothing was sent.",
                 retryable: true,
                 recoveryAction: "retry"
             ))
@@ -999,6 +1008,17 @@ actor SafariMCPServer {
             retryable: false,
             recoveryAction: "inspect_error"
         ))
+    }
+
+    private nonisolated static func ensureNativeInputPermission() throws {
+        guard AXIsProcessTrusted() else {
+            throw NativeInputError(failure: ToolFailure(
+                code: "native_input_permission_required",
+                message: "Native input requires Accessibility permission for the app running mcp-safari (Codex, Claude, or your terminal). Enable that app in System Settings > Privacy & Security > Accessibility. Standard input works without this permission.",
+                retryable: false,
+                recoveryAction: "grant_accessibility_to_mcp_client"
+            ))
+        }
     }
 
     private nonisolated static func postText(_ text: String, source: CGEventSource) throws {
@@ -1032,6 +1052,253 @@ actor SafariMCPServer {
         keyDown.post(tap: .cgSessionEventTap)
         keyUp.post(tap: .cgSessionEventTap)
         Thread.sleep(forTimeInterval: 0.005)
+    }
+
+    // MARK: - Native key combos (press_key native=true)
+
+    private func nativeRequested(_ args: [String: Value]) throws -> Bool {
+        if let native = args["native"], native.boolValue == nil {
+            throw ToolInputError("native must be a boolean")
+        }
+        return args["native"]?.boolValue == true
+    }
+
+    // Shared flow for native input tools: permission, trace, bridge
+    // preparation, then the CGEvent posting supplied by the caller.
+    private func runNativeAction(
+        _ action: String,
+        _ args: [String: Value],
+        perform: (BridgeResponse) throws -> String
+    ) async throws -> CallTool.Result {
+        try Self.ensureNativeInputPermission()
+        let traceSession = try await startTraceIfNeeded(args)
+        do {
+            let preparation = try await bridge.send(
+                action: action,
+                params: interactionParams(args),
+                timeout: Self.bridgeTimeout(args)
+            )
+            guard preparation.success else {
+                return try await resultAfterAction(preparation, args, traceSession: traceSession)
+            }
+
+            let message = try perform(preparation)
+            let response = BridgeResponse(
+                id: preparation.id,
+                success: true,
+                data: AnyCodable(message),
+                error: nil,
+                errorCode: nil,
+                retryable: nil,
+                recoveryAction: nil
+            )
+            return try await resultAfterAction(response, args, traceSession: traceSession)
+        } catch {
+            if let traceSession {
+                _ = try? await stopTraceResponse(traceSession, args, waitForDuration: false)
+            }
+            throw error
+        }
+    }
+
+    private func handlePressKey(_ args: [String: Value]) async throws -> CallTool.Result {
+        guard try nativeRequested(args) else {
+            return try await handleInteraction("press_key", args)
+        }
+        guard let key = args["key"]?.stringValue, !key.isEmpty else {
+            throw ToolInputError("key is required")
+        }
+        let combo = try Self.nativeKeyCombo(key)
+        return try await runNativeAction("native_press_key", args) { _ in
+            try Self.pressNativeKey(combo, deadline: Self.numberValue(args["_batchDeadline"]))
+        }
+    }
+
+    struct NativeKeyCombo: Equatable, Sendable {
+        let keyCode: CGKeyCode
+        let flags: CGEventFlags
+        let label: String
+    }
+
+    // macOS virtual keycodes (ANSI layout). Single characters map to the
+    // physical key; Shift in the combo produces the shifted character.
+    nonisolated static let nativeKeyCodes: [String: CGKeyCode] = [
+        "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
+        "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
+        "y": 16, "t": 17, "1": 18, "2": 19, "3": 20, "4": 21, "6": 22,
+        "5": 23, "=": 24, "9": 25, "7": 26, "-": 27, "8": 28, "0": 29,
+        "]": 30, "o": 31, "u": 32, "[": 33, "i": 34, "p": 35, "l": 37,
+        "j": 38, "'": 39, "k": 40, ";": 41, "\\": 42, ",": 43, "/": 44,
+        "n": 45, "m": 46, ".": 47, "`": 50,
+        "enter": 36, "return": 36, "tab": 48, "space": 49, "spacebar": 49,
+        " ": 49, "backspace": 51, "escape": 53, "esc": 53,
+        "delete": 117, "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
+        "arrowleft": 123, "arrowright": 124, "arrowdown": 125, "arrowup": 126,
+        "f1": 122, "f2": 120, "f3": 99, "f4": 118, "f5": 96, "f6": 97,
+        "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
+    ]
+
+    nonisolated static func nativeKeyCombo(_ keyString: String) throws -> NativeKeyCombo {
+        var parts = keyString.split(separator: "+", omittingEmptySubsequences: true).map(String.init)
+        guard let key = parts.popLast(), !key.isEmpty else {
+            throw ToolInputError("press_key requires a non-empty key such as Enter, Tab, or Meta+a")
+        }
+        var flags = CGEventFlags()
+        for modifier in parts {
+            switch modifier.lowercased() {
+            case "control", "ctrl": flags.insert(.maskControl)
+            case "shift": flags.insert(.maskShift)
+            case "alt", "option": flags.insert(.maskAlternate)
+            case "meta", "command", "cmd": flags.insert(.maskCommand)
+            default:
+                throw ToolInputError("Unknown modifier \(modifier). Use Control, Shift, Alt, or Meta.")
+            }
+        }
+        guard let code = nativeKeyCodes[key.lowercased()] else {
+            throw ToolInputError("Native press_key does not support \(key). Use Enter, Tab, Escape, Space, Backspace, Delete, arrows, Home, End, PageUp, PageDown, F1-F12, or a single character.")
+        }
+        return NativeKeyCombo(keyCode: code, flags: flags, label: keyString)
+    }
+
+    private nonisolated static func pressNativeKey(_ combo: NativeKeyCombo, deadline: Double? = nil) throws -> String {
+        let source = try nativeEventSource(deadline: deadline)
+        try postKey(code: combo.keyCode, flags: combo.flags, source: source)
+        try ensureSafariIsFrontmost(afterTyping: true)
+        return "Pressed \(combo.label) with native input"
+    }
+
+    // MARK: - Native pointer (move_pointer, drag native=true)
+
+    private struct NativePointerTargets: Sendable {
+        let from: CGPoint
+        let to: CGPoint?
+    }
+
+    private func handleHover(_ args: [String: Value]) async throws -> CallTool.Result {
+        guard try nativeRequested(args) else {
+            return try await handleInteraction("hover", args)
+        }
+        return try await runNativeAction("native_pointer", args) { preparation in
+            let targets = try Self.nativePointerTargets(from: preparation.data)
+            _ = try Self.moveNativePointer(to: targets.from, deadline: Self.numberValue(args["_batchDeadline"]))
+            return "Hovered with native input; pointer at (\(Int(targets.from.x)), \(Int(targets.from.y)))"
+        }
+    }
+
+    private func handleDrag(_ args: [String: Value]) async throws -> CallTool.Result {
+        guard try nativeRequested(args) else {
+            return try await handleInteraction("drag", args)
+        }
+        return try await runNativeAction("native_pointer", args) { preparation in
+            let targets = try Self.nativePointerTargets(from: preparation.data)
+            guard let to = targets.to else {
+                throw ToolInputError("drag requires toUid or toSelector")
+            }
+            return try Self.dragNativePointer(from: targets.from, to: to, deadline: Self.numberValue(args["_batchDeadline"]))
+        }
+    }
+
+    // Bridge payloads cross as JSON strings (background.js stringifies
+    // non-string data), so decode from the raw string.
+    private struct NativePointerPayload: Codable {
+        struct Point: Codable {
+            let x: Double
+            let y: Double
+        }
+        let from: Point
+        let to: Point?
+    }
+
+    private nonisolated static func nativePointerTargets(from data: AnyCodable?) throws -> NativePointerTargets {
+        guard let raw = data?.stringValue,
+              let payload = try? JSONDecoder().decode(NativePointerPayload.self, from: Data(raw.utf8))
+        else {
+            throw nativeInputUnavailable("The extension did not return pointer coordinates.")
+        }
+        return NativePointerTargets(
+            from: CGPoint(x: payload.from.x, y: payload.from.y),
+            to: payload.to.map { CGPoint(x: $0.x, y: $0.y) }
+        )
+    }
+
+    // Deadline check, frontmost guard, and event source in one call; every
+    // native posting path starts here.
+    private nonisolated static func nativeEventSource(deadline: Double? = nil) throws -> CGEventSource {
+        try checkNativeDeadline(deadline)
+        try ensureSafariIsFrontmost()
+        guard let source = CGEventSource(stateID: .hidSystemState) else {
+            throw nativeInputUnavailable("macOS could not create a native input event.")
+        }
+        return source
+    }
+
+    private nonisolated static func moveNativePointer(to target: CGPoint, deadline: Double? = nil) throws -> String {
+        let source = try nativeEventSource(deadline: deadline)
+        let start = CGEvent(source: nil)?.location ?? target
+        try postPointerPath(from: start, to: target, mouseType: .mouseMoved, source: source)
+        try ensureSafariIsFrontmost(afterTyping: true)
+        return "Moved pointer to (\(Int(target.x)), \(Int(target.y))) with native input"
+    }
+
+    private nonisolated static func dragNativePointer(from start: CGPoint, to target: CGPoint, deadline: Double? = nil) throws -> String {
+        let source = try nativeEventSource(deadline: deadline)
+        try postMouse(type: .mouseMoved, at: start, source: source)
+        Thread.sleep(forTimeInterval: 0.05)
+        try postMouse(type: .leftMouseDown, at: start, source: source)
+        // Pointer-sensor drag libraries arm on a delay or distance after
+        // mousedown; moving immediately can start a text selection instead.
+        Thread.sleep(forTimeInterval: 0.15)
+        do {
+            try checkNativeDeadline(deadline)
+            try postPointerPath(from: start, to: target, mouseType: .leftMouseDragged, source: source, maxSteps: 16, interval: 0.02)
+        } catch {
+            // Never leave the OS button down.
+            try? postMouse(type: .leftMouseUp, at: start, source: source)
+            throw error
+        }
+        Thread.sleep(forTimeInterval: 0.05)
+        try postMouse(type: .leftMouseUp, at: target, source: source)
+        try ensureSafariIsFrontmost(afterTyping: true)
+        return "Dragged from (\(Int(start.x)), \(Int(start.y))) to (\(Int(target.x)), \(Int(target.y))) with native input"
+    }
+
+    private nonisolated static func postMouse(
+        type: CGEventType,
+        at point: CGPoint,
+        source: CGEventSource
+    ) throws {
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else {
+            throw nativeInputUnavailable("macOS could not create a native mouse event.")
+        }
+        event.post(tap: .cgSessionEventTap)
+    }
+
+    // Interpolated so boundary events (mouseout/mouseleave, dragenter/dragover)
+    // fire for elements along the path, matching a real pointer's reachability.
+    private nonisolated static func postPointerPath(
+        from start: CGPoint,
+        to target: CGPoint,
+        mouseType: CGEventType,
+        source: CGEventSource,
+        maxSteps: Int = 10,
+        interval: TimeInterval = 0.015
+    ) throws {
+        let distance = hypot(target.x - start.x, target.y - start.y)
+        let count = max(1, min(maxSteps, Int(distance / 8)))
+        for step in 1...count {
+            let t = Double(step) / Double(count)
+            let point = CGPoint(
+                x: start.x + (target.x - start.x) * t,
+                y: start.y + (target.y - start.y) * t
+            )
+            try postMouse(type: mouseType, at: point, source: source)
+            Thread.sleep(forTimeInterval: interval)
+        }
     }
 
     private func handleFormInput(_ args: [String: Value]) async throws -> CallTool.Result {

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import Carbon
 import CoreGraphics
 import Foundation
 import Logging
@@ -1120,16 +1121,9 @@ actor SafariMCPServer {
         let label: String
     }
 
-    // macOS virtual keycodes (ANSI layout). Single characters map to the
-    // physical key; Shift in the combo produces the shifted character.
-    nonisolated static let nativeKeyCodes: [String: CGKeyCode] = [
-        "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7,
-        "c": 8, "v": 9, "b": 11, "q": 12, "w": 13, "e": 14, "r": 15,
-        "y": 16, "t": 17, "1": 18, "2": 19, "3": 20, "4": 21, "6": 22,
-        "5": 23, "=": 24, "9": 25, "7": 26, "-": 27, "8": 28, "0": 29,
-        "]": 30, "o": 31, "u": 32, "[": 33, "i": 34, "p": 35, "l": 37,
-        "j": 38, "'": 39, "k": 40, ";": 41, "\\": 42, ",": 43, "/": 44,
-        "n": 45, "m": 46, ".": 47, "`": 50,
+    // Virtual keycodes name a physical key position, not a character, so these
+    // are the same on every layout.
+    nonisolated static let namedKeyCodes: [String: CGKeyCode] = [
         "enter": 36, "return": 36, "tab": 48, "space": 49, "spacebar": 49,
         " ": 49, "backspace": 51, "escape": 53, "esc": 53,
         "delete": 117, "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
@@ -1138,7 +1132,89 @@ actor SafariMCPServer {
         "f7": 98, "f8": 100, "f9": 101, "f10": 109, "f11": 103, "f12": 111,
     ]
 
-    nonisolated static func nativeKeyCombo(_ keyString: String) throws -> NativeKeyCombo {
+    struct ResolvedCharacter: Equatable, Sendable {
+        let keyCode: CGKeyCode
+        let needsShift: Bool
+    }
+
+    /// Which physical key produces `character` on the keyboard layout that is
+    /// active right now.
+    ///
+    /// A character key cannot be a fixed keycode. Keycode 0 is `a` on QWERTY but
+    /// `q` on AZERTY, so a hardcoded table turns `Meta+a` into Command-Q — Quit
+    /// Safari — for a French or Belgian user. Ask the layout instead.
+    nonisolated static func currentLayoutKeyCode(for character: String) -> ResolvedCharacter? {
+        guard let layout = currentKeyboardLayout() else { return nil }
+        for shifted in [false, true] {
+            // Ascending, so the main block wins over the numeric keypad, which
+            // produces the same digits from a different position.
+            for code in CGKeyCode(0)...CGKeyCode(127)
+            where self.character(forKeyCode: code, shifted: shifted, layout: layout.data) == character {
+                return ResolvedCharacter(keyCode: code, needsShift: shifted)
+            }
+        }
+        return nil
+    }
+
+    nonisolated static func currentKeyboardLayoutName() -> String? {
+        currentKeyboardLayout()?.name
+    }
+
+    /// HIToolbox aborts the whole process if the Text Input Sources API is
+    /// entered from two threads at once, and it offers no main-thread shortcut
+    /// for a non-UI tool like this one. Tool calls run on the concurrency pool
+    /// and several clients can be served at the same time, so every TIS call
+    /// goes through this lock.
+    private nonisolated static let keyboardLayoutLock = NSLock()
+
+    private nonisolated static func currentKeyboardLayout() -> (data: Data, name: String)? {
+        keyboardLayoutLock.lock()
+        defer { keyboardLayoutLock.unlock() }
+
+        guard let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+              let dataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+        else { return nil }
+
+        // Copied, not referenced: the layout outlives the input source it came from.
+        let data = Data(Unmanaged<CFData>.fromOpaque(dataPointer).takeUnretainedValue() as Data)
+        let name = TISGetInputSourceProperty(source, kTISPropertyLocalizedName).map {
+            Unmanaged<CFString>.fromOpaque($0).takeUnretainedValue() as String
+        }
+        return (data, name ?? "the active keyboard layout")
+    }
+
+    private nonisolated static func character(
+        forKeyCode code: CGKeyCode,
+        shifted: Bool,
+        layout: Data
+    ) -> String? {
+        let capacity = 4
+        var characters = [UniChar](repeating: 0, count: capacity)
+        var length = 0
+        var deadKeyState: UInt32 = 0
+        let status = layout.withUnsafeBytes { raw -> OSStatus in
+            guard let base = raw.baseAddress else { return OSStatus(-1) }
+            return UCKeyTranslate(
+                base.assumingMemoryBound(to: UCKeyboardLayout.self),
+                UInt16(code),
+                UInt16(kUCKeyActionDown),
+                shifted ? UInt32(shiftKey >> 8) : 0,
+                UInt32(LMGetKbdType()),
+                OptionBits(kUCKeyTranslateNoDeadKeysBit),
+                &deadKeyState,
+                capacity,
+                &length,
+                &characters
+            )
+        }
+        guard status == noErr, length > 0 else { return nil }
+        return String(utf16CodeUnits: characters, count: length)
+    }
+
+    nonisolated static func nativeKeyCombo(
+        _ keyString: String,
+        resolveCharacter: (String) -> ResolvedCharacter? = currentLayoutKeyCode(for:)
+    ) throws -> NativeKeyCombo {
         var parts = keyString.split(separator: "+", omittingEmptySubsequences: true).map(String.init)
         guard let key = parts.popLast(), !key.isEmpty else {
             throw ToolInputError("press_key requires a non-empty key such as Enter, Tab, or Meta+a")
@@ -1154,10 +1230,21 @@ actor SafariMCPServer {
                 throw ToolInputError("Unknown modifier \(modifier). Use Control, Shift, Alt, or Meta.")
             }
         }
-        guard let code = nativeKeyCodes[key.lowercased()] else {
+
+        let normalized = key.lowercased()
+        if let code = namedKeyCodes[normalized] {
+            return NativeKeyCombo(keyCode: code, flags: flags, label: keyString)
+        }
+
+        guard normalized.count == 1 else {
             throw ToolInputError("Native press_key does not support \(key). Use Enter, Tab, Escape, Space, Backspace, Delete, arrows, Home, End, PageUp, PageDown, F1-F12, or a single character.")
         }
-        return NativeKeyCombo(keyCode: code, flags: flags, label: keyString)
+        guard let resolved = resolveCharacter(normalized) else {
+            let layout = currentKeyboardLayoutName().map { " on \($0)" } ?? ""
+            throw ToolInputError("Native press_key cannot type \(key)\(layout). Switch the keyboard layout, or use a named key such as Enter, Tab, or the arrows.")
+        }
+        if resolved.needsShift { flags.insert(.maskShift) }
+        return NativeKeyCombo(keyCode: resolved.keyCode, flags: flags, label: keyString)
     }
 
     private nonisolated static func pressNativeKey(_ combo: NativeKeyCombo, deadline: Double? = nil) throws -> String {

--- a/MCPServer/Tests/MCPSafariTests/NativeKeyComboTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/NativeKeyComboTests.swift
@@ -1,0 +1,65 @@
+import CoreGraphics
+import Testing
+@testable import MCPSafari
+
+struct NativeKeyComboTests {
+    private func combo(_ key: String) throws -> SafariMCPServer.NativeKeyCombo {
+        try SafariMCPServer.nativeKeyCombo(key)
+    }
+
+    @Test func mapsNamedKeys() throws {
+        #expect(try combo("Enter").keyCode == 36)
+        #expect(try combo("Escape").keyCode == 53)
+        #expect(try combo("Tab").keyCode == 48)
+        #expect(try combo("Space").keyCode == 49)
+        #expect(try combo("Backspace").keyCode == 51)
+        #expect(try combo("Delete").keyCode == 117)
+        #expect(try combo("ArrowDown").keyCode == 125)
+        #expect(try combo("ArrowUp").keyCode == 126)
+        #expect(try combo("ArrowLeft").keyCode == 123)
+        #expect(try combo("ArrowRight").keyCode == 124)
+        #expect(try combo("Home").keyCode == 115)
+        #expect(try combo("End").keyCode == 119)
+        #expect(try combo("PageUp").keyCode == 116)
+        #expect(try combo("PageDown").keyCode == 121)
+        #expect(try combo("F5").keyCode == 96)
+    }
+
+    @Test func mapsSingleCharactersToPhysicalKeys() throws {
+        #expect(try combo("a").keyCode == 0)
+        #expect(try combo("z").keyCode == 6)
+        #expect(try combo("0").keyCode == 29)
+        #expect(try combo("A").keyCode == 0)
+        #expect(try combo("A").flags == [])
+    }
+
+    @Test func parsesModifiers() throws {
+        #expect(try combo("Meta+a").flags == .maskCommand)
+        #expect(try combo("cmd+a").flags == .maskCommand)
+        #expect(try combo("Control+c").flags == .maskControl)
+        #expect(try combo("Shift+Tab").flags == .maskShift)
+        #expect(try combo("Alt+ArrowLeft").flags == .maskAlternate)
+        #expect(try combo("Control+Shift+r").flags == [.maskControl, .maskShift])
+        #expect(try combo("Enter").flags == [])
+    }
+
+    @Test func rejectsUnknownKeysAndModifiers() {
+        #expect(errorMessage("") == "press_key requires a non-empty key such as Enter, Tab, or Meta+a")
+        #expect(errorMessage("F13")?.hasPrefix("Native press_key does not support F13") == true)
+        #expect(errorMessage("Hyper+a") == "Unknown modifier Hyper. Use Control, Shift, Alt, or Meta.")
+        #expect(errorMessage("MediaPlayPause")?.hasPrefix("Native press_key does not support MediaPlayPause") == true)
+    }
+
+    private func errorMessage(_ key: String) -> String? {
+        do {
+            _ = try SafariMCPServer.nativeKeyCombo(key)
+            return nil
+        } catch {
+            return String(describing: error)
+        }
+    }
+
+    @Test func keepsOriginalLabel() throws {
+        #expect(try combo("Meta+Shift+z").label == "Meta+Shift+z")
+    }
+}

--- a/MCPServer/Tests/MCPSafariTests/NativeKeyComboTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/NativeKeyComboTests.swift
@@ -3,8 +3,20 @@ import Testing
 @testable import MCPSafari
 
 struct NativeKeyComboTests {
+    // Stand-in for a QWERTY layout, so these tests do not depend on whatever
+    // layout the machine running them happens to have selected.
+    private static let qwerty: [String: SafariMCPServer.ResolvedCharacter] = [
+        "a": .init(keyCode: 0, needsShift: false),
+        "z": .init(keyCode: 6, needsShift: false),
+        "q": .init(keyCode: 12, needsShift: false),
+        "c": .init(keyCode: 8, needsShift: false),
+        "r": .init(keyCode: 15, needsShift: false),
+        "0": .init(keyCode: 29, needsShift: false),
+        "?": .init(keyCode: 44, needsShift: true),
+    ]
+
     private func combo(_ key: String) throws -> SafariMCPServer.NativeKeyCombo {
-        try SafariMCPServer.nativeKeyCombo(key)
+        try SafariMCPServer.nativeKeyCombo(key) { Self.qwerty[$0] }
     }
 
     @Test func mapsNamedKeys() throws {
@@ -52,10 +64,77 @@ struct NativeKeyComboTests {
 
     private func errorMessage(_ key: String) -> String? {
         do {
-            _ = try SafariMCPServer.nativeKeyCombo(key)
+            _ = try SafariMCPServer.nativeKeyCombo(key) { Self.qwerty[$0] }
             return nil
         } catch {
             return String(describing: error)
+        }
+    }
+
+    // Keycode 0 is `a` on QWERTY and `q` on AZERTY. Resolving `Meta+a` against a
+    // fixed ANSI table would post Command-Q — Quit Safari — for a French user.
+    @Test func characterKeysFollowTheActiveLayout() throws {
+        let azerty: [String: SafariMCPServer.ResolvedCharacter] = [
+            "a": .init(keyCode: 12, needsShift: false),
+            "q": .init(keyCode: 0, needsShift: false),
+        ]
+        let combo = try SafariMCPServer.nativeKeyCombo("Meta+a") { azerty[$0] }
+
+        // Not keycode 0, which is Q — and therefore Quit — on this layout.
+        #expect(combo.keyCode == 12)
+        #expect(combo.flags == .maskCommand)
+        #expect(try SafariMCPServer.nativeKeyCombo("Meta+q") { azerty[$0] }.keyCode == 0)
+    }
+
+    @Test func namedKeysIgnoreTheLayout() throws {
+        // Physical positions, so they resolve without consulting a layout at all.
+        let noCharacters: (String) -> SafariMCPServer.ResolvedCharacter? = { _ in nil }
+        #expect(try SafariMCPServer.nativeKeyCombo("Tab", resolveCharacter: noCharacters).keyCode == 48)
+        #expect(try SafariMCPServer.nativeKeyCombo("Escape", resolveCharacter: noCharacters).keyCode == 53)
+        #expect(try SafariMCPServer.nativeKeyCombo("ArrowUp", resolveCharacter: noCharacters).keyCode == 126)
+    }
+
+    @Test func refusesCharactersTheLayoutCannotProduce() {
+        // Better to fail than to post whichever key happens to sit at that code.
+        let cyrillicOnly: (String) -> SafariMCPServer.ResolvedCharacter? = { _ in nil }
+        var message: String?
+        do {
+            _ = try SafariMCPServer.nativeKeyCombo("Meta+a", resolveCharacter: cyrillicOnly)
+        } catch {
+            message = String(describing: error)
+        }
+        #expect(message?.hasPrefix("Native press_key cannot type a") == true)
+    }
+
+    @Test func addsShiftForCharactersThatNeedIt() throws {
+        let combo = try combo("?")
+        #expect(combo.keyCode == 44)
+        #expect(combo.flags == .maskShift)
+    }
+
+    @Test func readsTheRealKeyboardLayout() throws {
+        // The live path the tool actually uses; every Mac layout can produce
+        // some character from the main block.
+        #expect(SafariMCPServer.currentLayoutKeyCode(for: "\u{1F600}") == nil)
+        if SafariMCPServer.currentKeyboardLayoutName() != nil {
+            #expect(SafariMCPServer.currentLayoutKeyCode(for: " ") != nil)
+        }
+    }
+
+    // HIToolbox calls abort() when the Text Input Sources API is entered from
+    // two threads at once. mcp-safari serves several clients concurrently and
+    // resolves keys off the main thread, so an unserialized read takes the
+    // whole server down rather than failing one call.
+    @Test func readsTheLayoutFromManyThreadsWithoutAborting() async {
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<32 {
+                group.addTask { SafariMCPServer.currentLayoutKeyCode(for: " ") != nil }
+                group.addTask { SafariMCPServer.currentKeyboardLayoutName() != nil }
+            }
+            var results: [Bool] = []
+            for await resolved in group { results.append(resolved) }
+            #expect(results.count == 64)
+            #expect(Set(results).count == 1, "every concurrent read agrees")
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -259,13 +259,15 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 | `form_input` | Batch fill form fields (CSS selector → value map) |
 | `select_option` | Select a dropdown option by value or label |
 | `scroll` | Scroll page or element in any direction |
-| `press_key` | Press key combinations (e.g., `Enter`, `Meta+a`, `Control+c`) |
-| `hover` | Hover to trigger tooltips, menus, or hover handlers (pointer + mouse events) |
-| `drag` | Drag and drop between elements along an interpolated pointer path |
+| `press_key` | Press key combinations (e.g., `Enter`, `Meta+a`, `Control+c`); `native: true` sends a real macOS key event |
+| `hover` | Hover to trigger tooltips, menus, or hover handlers (pointer + mouse events); `native: true` moves the real OS pointer for true `:hover` |
+| `drag` | Drag and drop between elements along an interpolated pointer path; `native: true` performs a real macOS mouse drag |
 | `upload_file` | Attach local files to an `<input type="file">` |
 | `drop_file` | Drop local files onto an element |
 
 > **Note:** Interaction tools drive elements via synthetic DOM events (and React-compatible value setting for text), which works across the vast majority of sites. Because the events are synthetic, `press_key` modifier combos (e.g. `Meta+a`, `Control+c`) and `drag` reach page-level JS handlers but do **not** trigger native browser actions — clipboard copy/paste, select-all, or HTML5 native drag-and-drop. Synthetic events also never apply CSS `:hover`, so `hover` can verify hover *handlers* (including `onPointerEnter`) but not hover *styling*. Use `type_text`/`form_input` for text entry and `javascript_tool` when a true native action is required.
+>
+> `press_key`, `hover`, and `drag` with `native: true` send real macOS events instead: trusted keys that trigger default actions, a pointer path that produces true `:hover` and boundary events, and drags that threshold-based libraries (pointer sensors) accept. They require Safari to be frontmost and Accessibility permission for the app running the server, and move the user's real pointer. Screen coordinates assume 100% page zoom.
 
 ### Dialogs
 

--- a/Tests/content-native-pointer.test.mjs
+++ b/Tests/content-native-pointer.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+
+// Geometry: window at screen (100, 125), 100 px of top chrome, no side
+// borders. Element rect center (60, 65) must land at screen (160, 290).
+const WINDOW = {
+    screenX: 100,
+    screenY: 125,
+    outerWidth: 1000,
+    innerWidth: 1000,
+    outerHeight: 900,
+    innerHeight: 800,
+};
+
+function el(rect) {
+    return {
+        nodeType: ELEMENT_NODE,
+        tagName: "DIV",
+        hidden: false,
+        scrollIntoView() {},
+        getBoundingClientRect: () => rect,
+    };
+}
+
+function loadContent({ target, toTarget, window: windowValues } = {}) {
+    let listener;
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document: {
+            body: null,
+            documentElement: null,
+            activeElement: null,
+            querySelector: (selector) => {
+                if (selector === "#to") return toTarget || null;
+                return target || null;
+            },
+        },
+        Node: { ELEMENT_NODE, TEXT_NODE: 3 },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            ...WINDOW,
+            ...windowValues,
+        },
+    });
+    return (action, params) => new Promise((r) => listener({ action, params }, {}, r));
+}
+
+test("native_pointer_points converts an element center to screen points", async () => {
+    const target = el({ left: 50, top: 60, width: 20, height: 10 });
+    const call = loadContent({ target });
+
+    const { data, error } = await call("native_pointer_points", { selector: "#target" });
+
+    assert.equal(error, null);
+    assert.deepEqual(JSON.parse(JSON.stringify(data)), { from: { x: 160, y: 290 } });
+});
+
+test("native_pointer_points passes x/y through the same conversion", async () => {
+    const call = loadContent();
+
+    const { data } = await call("native_pointer_points", { x: 10, y: 20 });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(data)), { from: { x: 110, y: 245 } });
+});
+
+test("native_pointer_points resolves drag endpoints", async () => {
+    const target = el({ left: 0, top: 0, width: 10, height: 10 });
+    const toTarget = el({ left: 200, top: 300, width: 40, height: 20 });
+    const call = loadContent({ target, toTarget });
+
+    const { data } = await call("native_pointer_points", {
+        fromSelector: "#from",
+        toSelector: "#to",
+    });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(data)), { from: { x: 105, y: 230 }, to: { x: 320, y: 535 } });
+});
+
+test("native_pointer_points rejects calls without a target", async () => {
+    const call = loadContent();
+
+    const response = await call("native_pointer_points", {});
+
+    assert.equal(response.data, null);
+    assert.equal(response.errorCode, "invalid_input");
+});
+
+test("native_pointer_points measures both drag endpoints after all scrolling", async () => {
+    // A distant drag target scrolls the source off-screen; the source point
+    // must be measured after all scrolling (and here fails the bounds check
+    // rather than dragging whatever sits at the stale point).
+    let scrollOffset = 0;
+    const scrollingEl = (baseTop) => ({
+        nodeType: ELEMENT_NODE,
+        tagName: "DIV",
+        hidden: false,
+        scrollIntoView() {
+            scrollOffset = baseTop;
+        },
+        getBoundingClientRect: () => ({
+            left: 0,
+            top: baseTop - scrollOffset,
+            width: 10,
+            height: 10,
+        }),
+    });
+    const target = scrollingEl(100);
+    const toTarget = scrollingEl(2000);
+    const call = loadContent({ target, toTarget });
+
+    const response = await call("native_pointer_points", {
+        fromSelector: "#from",
+        toSelector: "#to",
+    });
+
+    assert.equal(response.data, null);
+    assert.equal(response.errorCode, "invalid_input");
+    assert.equal(scrollOffset, 2000);
+});
+
+test("native_pointer_points puts the full side-chrome width on the left", async () => {
+    // Safari's sidebar shrinks innerWidth from the left only.
+    const target = el({ left: 50, top: 60, width: 20, height: 10 });
+    const call = loadContent({
+        target,
+        window: { outerWidth: 1320, innerWidth: 1000 },
+    });
+
+    const { data } = await call("native_pointer_points", { selector: "#target" });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(data)), {
+        from: { x: 100 + 320 + 60, y: 290 },
+    });
+});
+
+test("native_pointer_points rejects points outside the viewport", async () => {
+    const call = loadContent();
+
+    const response = await call("native_pointer_points", { x: 5000, y: -50 });
+
+    assert.equal(response.data, null);
+    assert.equal(response.errorCode, "invalid_input");
+});


### PR DESCRIPTION
## Problem

Synthetic events can't trigger default key actions, apply real `:hover`, or drive pointer-sensor drag libraries — Tab never moves focus, Escape doesn't dismiss dialogs, and dnd-kit's `PointerSensor` never sees a drag begin.

## Root cause

The interaction tools only dispatch DOM events; the only native path today is `type_text(native: true)` from #39.

## Fix

`native: true` on `press_key`, `hover`, and `drag`, posting real CGEvents — the same opt-in shape `type_text` already has:

- `press_key(native: true)` — trusted keys (named keys, single characters, modifier combos).
- `hover(native: true)` — moves the real OS pointer to the target, so `:hover` applies and boundary events fire along the path. x/y targets work once #46 lands; the extension side already accepts coordinates.
- `drag(native: true)` — a real mouse drag that pointer-sensor libraries accept.

Safety: points outside the viewport are rejected (a real OS event there could hit another app), the page is focused before native keys so address-bar focus can't swallow them, drag endpoints are measured after all scrolling, and `run_steps` deadlines apply with a guaranteed `leftMouseUp` on abort. Screen-point math assumes 100% page zoom; two concurrent native calls can interleave focus and posting, same limitation as #39.

## Validation

- `swift test` 36/36 (5 new), `node --test Tests/*.mjs` 65/65 (7 new).
- Live gate on an installed build: native keydown arrives with `isTrusted: true` (synthetic: `false`), `hover(native: true)` sets `:hover` with the pointer at the element's exact center, native Tab moves focus between inputs, and a native drag moves an item between dnd-kit columns at `Distance(8)`.
