### PR TITLE
fix: dispatch click and hover at the requested x/y point instead of the element center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
 
 ### Bug Fixes
+- `click` and `hover` with `x`/`y` now dispatch events at the requested point instead of the target element's center, so a specific point inside a large element (e.g. a canvas) can be targeted.
 - `press_key` and `type_text`'s `submitKey` no longer emit `keypress` for keys that produce no character (Escape, Tab, arrow keys) or for Ctrl/Meta combos, matching the UI Events spec; single characters and Enter still fire it.
 - `hover` now dispatches the pointer-event family (`pointerover`/`pointerenter`/`pointermove`) alongside the mouse events in real pointer order, so Pointer Events handlers such as React's `onPointerEnter` run; accepts `x`/`y` coordinates like `click`; and reports that synthetic events never apply CSS `:hover`.
 - `drag` now moves along an interpolated pointer-event path with dwell instead of jumping from source to target, so distance-threshold drag libraries (e.g. dnd-kit's `PointerSensor`) start a drag; it fails with `input_not_applied` when the gesture produced no DOM change instead of reporting a silent no-op.

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -1188,9 +1188,12 @@
             });
         };
 
+        // x/y wins over uid/selector/text here exactly as it does for the
+        // synthetic path, so native and synthetic hover land on the same point.
+        const pointRequested = params.x !== undefined && params.y !== undefined;
         const fromEl = params.fromUid || params.fromSelector
             ? resolveElement({ uid: params.fromUid, selector: params.fromSelector })
-            : (params.uid || params.selector || params.text)
+            : (!pointRequested && (params.uid || params.selector || params.text))
                 ? resolveElement(params)
                 : null;
         const toEl = params.toUid || params.toSelector
@@ -1214,7 +1217,7 @@
         let from;
         if (fromEl) {
             from = centerOf(fromEl);
-        } else if (params.x !== undefined && params.y !== undefined) {
+        } else if (pointRequested) {
             from = checked({ x: Number(params.x), y: Number(params.y) });
         } else {
             throw toolError(

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -581,7 +581,7 @@
                     false,
                     "take_snapshot"
                 );
-            simulateClick(el, params.doubleClick);
+            simulateClick(el, params.doubleClick, { x: params.x, y: params.y });
             return `Clicked element at (${params.x}, ${params.y}): <${el.tagName.toLowerCase()}>`;
         }
 
@@ -601,12 +601,19 @@
         return `Clicked <${desc}>${el.textContent ? ': "' + el.textContent.trim().substring(0, 50) + '"' : ""}`;
     }
 
-    function simulateClick(element, doubleClick) {
-        element.scrollIntoView({ behavior: "instant", block: "center" });
-
-        const rect = element.getBoundingClientRect();
-        const x = rect.left + rect.width / 2;
-        const y = rect.top + rect.height / 2;
+    function simulateClick(element, doubleClick, point) {
+        let x, y;
+        if (point) {
+            // elementFromPoint already proved the point is visible; scrolling
+            // would move the element out from under the requested coordinates.
+            x = point.x;
+            y = point.y;
+        } else {
+            element.scrollIntoView({ behavior: "instant", block: "center" });
+            const rect = element.getBoundingClientRect();
+            x = rect.left + rect.width / 2;
+            y = rect.top + rect.height / 2;
+        }
 
         const eventOpts = {
             bubbles: true,
@@ -1002,6 +1009,7 @@
 
     function hoverElement(params) {
         let el = null;
+        let x, y;
         if (params.x !== undefined && params.y !== undefined) {
             el = document.elementFromPoint(params.x, params.y);
             if (!el) {
@@ -1012,27 +1020,32 @@
                     "take_snapshot"
                 );
             }
+            // elementFromPoint already proved the point is visible; scrolling
+            // would move the element out from under the requested coordinates.
+            x = params.x;
+            y = params.y;
         } else {
             el = resolveElement(params);
-        }
-        if (!el) {
-            throw toolError(
-                "invalid_input",
-                "hover requires uid, selector, text, or x and y",
-                false,
-                "fix_input"
-            );
+            if (!el) {
+                throw toolError(
+                    "invalid_input",
+                    "hover requires uid, selector, text, or x and y",
+                    false,
+                    "fix_input"
+                );
+            }
+            el.scrollIntoView({ behavior: "instant", block: "center" });
+            const rect = el.getBoundingClientRect();
+            x = rect.left + rect.width / 2;
+            y = rect.top + rect.height / 2;
         }
 
-        el.scrollIntoView({ behavior: "instant", block: "center" });
-
-        const rect = el.getBoundingClientRect();
         const eventOpts = {
             bubbles: true,
             cancelable: true,
             view: window,
-            clientX: rect.left + rect.width / 2,
-            clientY: rect.top + rect.height / 2,
+            clientX: x,
+            clientY: y,
             button: 0,
             buttons: 0,
         };

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -148,6 +148,8 @@ actor SafariMCPServer {
     private static let sel: Value = .object(["type": .string("string"), "description": .string("CSS selector")])
     private static let txt: Value = .object(["type": .string("string"), "description": .string("Visible text to match")])
     private static let snap: Value = .object(["type": .string("boolean"), "description": .string("Return snapshot after action")])
+    private static let coordX: Value = .object(["type": .string("number"), "description": .string("Viewport x in CSS px; events dispatch at this exact point (overrides uid/selector/text)")])
+    private static let coordY: Value = .object(["type": .string("number"), "description": .string("Viewport y in CSS px")])
     private static let waitSel: Value = .object(["type": .string("string"), "description": .string("Wait for CSS selector after action")])
     private static let waitTxt: Value = .object(["type": .string("string"), "description": .string("Wait for visible text after action")])
     private static let waitTimeout: Value = .object(["type": .string("number"), "description": .string("Post-action wait timeout seconds (default: 10)")])
@@ -310,8 +312,8 @@ actor SafariMCPServer {
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
                         "uid": Self.uid, "selector": Self.sel, "text": Self.txt,
-                        "x": .object(["type": .string("number")]),
-                        "y": .object(["type": .string("number")]),
+                        "x": Self.coordX,
+                        "y": Self.coordY,
                         "doubleClick": .object(["type": .string("boolean")]),
                         "includeSnapshot": Self.snap, "tabId": Self.tab,
                     ])),
@@ -401,8 +403,8 @@ actor SafariMCPServer {
                     "type": .string("object"),
                     "properties": .object(Self.withActionOptions([
                         "uid": Self.uid, "selector": Self.sel, "text": Self.txt,
-                        "x": .object(["type": .string("number")]),
-                        "y": .object(["type": .string("number")]),
+                        "x": Self.coordX,
+                        "y": Self.coordY,
                         "native": .object([
                             "type": .string("boolean"),
                             "description": .string("Move the real OS pointer; requires Safari to already be the frontmost application and Accessibility permission"),

--- a/Tests/content-input-fidelity.test.mjs
+++ b/Tests/content-input-fidelity.test.mjs
@@ -250,6 +250,76 @@ test("hover accepts x and y like click", async () => {
     assert.equal(missing.errorCode, "target_not_found");
 });
 
+// ─── point targeting: x/y dispatches at the requested point ──────────
+
+function pointTarget() {
+    const events = [];
+    const target = el("canvas", {
+        extra: {
+            getBoundingClientRect: () => ({ left: 100, top: 100, x: 100, y: 100, width: 200, height: 100 }),
+            dispatchEvent(event) { events.push(event); return true; },
+        },
+    });
+    return { events, target };
+}
+
+test("click with x/y dispatches at the requested point, not the element center", async () => {
+    const { events, target } = pointTarget();
+    let scrolled = false;
+    target.scrollIntoView = () => { scrolled = true; };
+    const call = loadContent(el("body", {}, [target]), { elementFromPoint: () => target });
+
+    assert.equal((await call("click", { x: 110, y: 105 })).error, null);
+    assert.equal((await call("click", { x: 250, y: 180 })).error, null);
+
+    const clicks = events.filter((e) => e.type === "click");
+    assert.deepEqual(
+        clicks.map((e) => [e.clientX, e.clientY]),
+        [[110, 105], [250, 180]],
+        "two requested points produce two distinct dispatch points"
+    );
+    assert.equal(scrolled, false, "the hit-tested point is already visible; scrolling would move it");
+});
+
+test("click without x/y still dispatches at the element center", async () => {
+    const { events, target } = pointTarget();
+    const call = loadContent(el("body", {}, [target]), { querySelector: () => target });
+
+    const response = await call("click", { selector: "canvas" });
+
+    assert.equal(response.error, null);
+    const click = events.find((e) => e.type === "click");
+    assert.equal(click.clientX, 200);
+    assert.equal(click.clientY, 150);
+});
+
+test("hover with x/y dispatches at the requested point, not the element center", async () => {
+    const { events, target } = pointTarget();
+    let scrolled = false;
+    target.scrollIntoView = () => { scrolled = true; };
+    const call = loadContent(el("body", {}, [target]), { elementFromPoint: () => target });
+
+    const response = await call("hover", { x: 130, y: 190 });
+
+    assert.equal(response.error, null);
+    const move = events.find((e) => e.type === "pointermove");
+    assert.equal(move.clientX, 130);
+    assert.equal(move.clientY, 190);
+    assert.equal(scrolled, false, "the hit-tested point is already visible; scrolling would move it");
+});
+
+test("hover without x/y still dispatches at the element center", async () => {
+    const { events, target } = pointTarget();
+    const call = loadContent(el("body", {}, [target]), { querySelector: () => target });
+
+    const response = await call("hover", { selector: "canvas" });
+
+    assert.equal(response.error, null);
+    const move = events.find((e) => e.type === "pointermove");
+    assert.equal(move.clientX, 200);
+    assert.equal(move.clientY, 150);
+});
+
 // ─── drag pointer path and no-op detection ───────────────────────────
 
 function dragHarness({ throwOn } = {}) {

--- a/Tests/content-native-pointer.test.mjs
+++ b/Tests/content-native-pointer.test.mjs
@@ -155,3 +155,17 @@ test("native_pointer_points rejects points outside the viewport", async () => {
     assert.equal(response.data, null);
     assert.equal(response.errorCode, "invalid_input");
 });
+
+test("x/y overrides a resolvable selector, matching the synthetic path", async () => {
+    // The schema states x/y takes precedence over uid/selector/text. Synthetic
+    // hover honours that; the native path must land on the same point rather
+    // than the element's centre.
+    const target = el({ left: 10, top: 10, x: 10, y: 10, width: 100, height: 100 });
+    const call = loadContent({ target });
+
+    const { data } = await call("native_pointer_points", { selector: "#target", x: 400, y: 300 });
+
+    assert.deepEqual(JSON.parse(JSON.stringify(data)), {
+        from: { x: 100 + 400, y: 125 + 100 + 300 },
+    });
+});


### PR DESCRIPTION
## Problem

`click` and `hover` accept `x`/`y` but dispatch every event at the target element's center, so neither tool can hit a specific point inside a large element such as a canvas. Follow-up to the known gap you noted on #46: "worth fixing in both at once rather than in either separately."

## Root cause

Both handlers use `x`/`y` only for the `elementFromPoint` hit-test; `simulateClick` and `hoverElement` then recompute the dispatch point as `rect.left + rect.width / 2`, `rect.top + rect.height / 2`.

## Fix

With `x`/`y`, events now dispatch at exactly that viewport point (CSS px); `x`/`y` keep taking precedence over `uid`/`selector`/`text`, now stated in the schema descriptions. The x/y path also skips `scrollIntoView`: `elementFromPoint` already proved the point is visible, and scrolling would move the element out from under the requested coordinates. The element path is unchanged (scroll into view, dispatch at center).

## Validation

- `node --test Tests/*.mjs`: 79/79 (4 new: requested-point vs center for both tools, no-scroll on the x/y path).
- `swift test`: 31/31; debug and release builds; the CI extension xcodebuild.
- Live gate through the full MCP path on a 600x300 canvas fixture centered at (350,200): clicks at (100,100) and (600,300), hovers at (150,120) and (550,320) — the page recorded exactly the four requested points; a selector click still recorded (350,200).
