### PR TITLE
feat: add --log-level and quiet the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Changed
+- Added `--log-level` and the `MCP_SAFARI_LOG_LEVEL` environment variable, and lowered the default from `info` to `notice`. Logs go to stderr, which MCP clients surface to the user, so routine startup and connection lines no longer appear unless asked for. `--verbose` is unchanged as a shorthand for `debug`.
 - Auth tokens are now written to `~/Library/Application Support/MCPSafari/tokens/<port>` in addition to the previous `~/.config/mcp-safari/tokens/<port>`, and the extension prefers the new location. A `~/.config` symlinked into a dotfiles repo resolves outside the sandboxed extension's read grant, which left the extension permanently disconnected with no diagnostic.
 - `mcp-safari doctor` reports a new `token_path` check that warns when the token directory resolves somewhere other than its literal path, and now names the token file path it checked.
 

--- a/MCPServer/Sources/mcp-safari/Diagnostics.swift
+++ b/MCPServer/Sources/mcp-safari/Diagnostics.swift
@@ -1,18 +1,28 @@
 import Foundation
+import Logging
 
 enum CLICommand: Equatable {
-    case serve(port: UInt16, verbose: Bool)
+    case serve(port: UInt16, logLevel: Logger.Level)
     case doctor(port: UInt16, json: Bool)
 }
+
+/// Routine lifecycle chatter is not worth surfacing by default: stderr is the
+/// only channel a stdio server has, and MCP clients show it to the user.
+/// Warnings and errors still come through; `--log-level info` brings the rest back.
+let defaultLogLevel: Logger.Level = .notice
 
 struct CLIError: Error, CustomStringConvertible {
     let description: String
 }
 
-func parseCommand(arguments: [String]) throws -> CLICommand {
+func parseCommand(
+    arguments: [String],
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) throws -> CLICommand {
     let doctorMode = arguments.first == "doctor"
     let options = doctorMode ? Array(arguments.dropFirst()) : arguments
     var port: UInt16 = 8089
+    var logLevel: Logger.Level?
     var verbose = false
     var json = false
     var index = 0
@@ -25,6 +35,15 @@ func parseCommand(arguments: [String]) throws -> CLICommand {
             }
             port = parsed
             index += 2
+        case "--log-level" where !doctorMode:
+            guard index + 1 < options.count else {
+                throw CLIError(description: logLevelUsage)
+            }
+            guard let parsed = Logger.Level(rawValue: options[index + 1].lowercased()) else {
+                throw CLIError(description: "Unknown log level: \(options[index + 1]). \(logLevelUsage)")
+            }
+            logLevel = parsed
+            index += 2
         case "--verbose" where !doctorMode:
             verbose = true
             index += 1
@@ -36,8 +55,18 @@ func parseCommand(arguments: [String]) throws -> CLICommand {
         }
     }
 
-    return doctorMode ? .doctor(port: port, json: json) : .serve(port: port, verbose: verbose)
+    if doctorMode { return .doctor(port: port, json: json) }
+
+    // An explicit flag beats --verbose, which beats the environment. MCP client
+    // configs can set env but not always argv, so both need to work.
+    let fromEnvironment = environment["MCP_SAFARI_LOG_LEVEL"].map { value -> Logger.Level in
+        Logger.Level(rawValue: value.lowercased()) ?? defaultLogLevel
+    }
+    let resolved = logLevel ?? (verbose ? .debug : nil) ?? fromEnvironment ?? defaultLogLevel
+    return .serve(port: port, logLevel: resolved)
 }
+
+let logLevelUsage = "Use trace, debug, info, notice, warning, error, or critical."
 
 enum MCPSafariProduct {
     static let version = "0.2.9"

--- a/MCPServer/Sources/mcp-safari/main.swift
+++ b/MCPServer/Sources/mcp-safari/main.swift
@@ -17,12 +17,12 @@ case .doctor(let port, let json):
     print(output)
     exit(report.exitCode)
 
-case .serve(let port, let verbose):
+case .serve(let port, let logLevel):
     // Log to stderr so stdout is reserved for MCP stdio transport
     var logger = Logger(label: "mcp-safari") { label in
         StreamLogHandler.standardError(label: label)
     }
-    logger.logLevel = verbose ? .debug : .info
+    logger.logLevel = logLevel
 
     logger.info("Starting Safari MCP server on WebSocket port \(port)")
 

--- a/MCPServer/Tests/MCPSafariTests/DoctorTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/DoctorTests.swift
@@ -86,6 +86,54 @@ struct DoctorTests {
         #expect(throws: CLIError.self) {
             try parseCommand(arguments: ["doctor", "--verbose"])
         }
+        #expect(throws: CLIError.self) {
+            try parseCommand(arguments: ["doctor", "--log-level", "debug"])
+        }
+    }
+
+    @Test func serveDefaultsToQuietLogging() throws {
+        // stderr is the only channel a stdio server has and clients show it to
+        // the user, so routine lifecycle lines stay off unless asked for.
+        #expect(try parseCommand(arguments: [], environment: [:]) == .serve(port: 8089, logLevel: .notice))
+    }
+
+    @Test func logLevelComesFromFlagVerboseOrEnvironment() throws {
+        #expect(
+            try parseCommand(arguments: ["--log-level", "warning"], environment: [:])
+                == .serve(port: 8089, logLevel: .warning)
+        )
+        #expect(
+            try parseCommand(arguments: ["--log-level", "INFO"], environment: [:])
+                == .serve(port: 8089, logLevel: .info)
+        )
+        #expect(
+            try parseCommand(arguments: ["--verbose"], environment: [:])
+                == .serve(port: 8089, logLevel: .debug)
+        )
+        #expect(
+            try parseCommand(arguments: [], environment: ["MCP_SAFARI_LOG_LEVEL": "trace"])
+                == .serve(port: 8089, logLevel: .trace)
+        )
+        // An explicit flag wins over both --verbose and the environment.
+        #expect(
+            try parseCommand(
+                arguments: ["--verbose", "--log-level", "error"],
+                environment: ["MCP_SAFARI_LOG_LEVEL": "trace"]
+            ) == .serve(port: 8089, logLevel: .error)
+        )
+        #expect(
+            try parseCommand(arguments: ["--verbose"], environment: ["MCP_SAFARI_LOG_LEVEL": "trace"])
+                == .serve(port: 8089, logLevel: .debug)
+        )
+    }
+
+    @Test func rejectsAnUnknownLogLevel() {
+        #expect(throws: CLIError.self) {
+            try parseCommand(arguments: ["--log-level", "chatty"], environment: [:])
+        }
+        #expect(throws: CLIError.self) {
+            try parseCommand(arguments: ["--log-level"], environment: [:])
+        }
     }
 
     @Test func missingInstallationHasActionableErrors() throws {

--- a/README.md
+++ b/README.md
@@ -208,7 +208,13 @@ For ports outside the default range, add them manually in the extension popup or
 | Flag | Description |
 |------|-------------|
 | `--port <n>` / `-p <n>` | WebSocket port (default: `8089`) |
-| `--verbose` | Debug-level logging to stderr |
+| `--log-level <level>` | `trace`, `debug`, `info`, `notice`, `warning`, `error`, or `critical` (default: `notice`) |
+| `--verbose` | Shorthand for `--log-level debug` |
+
+Logs go to stderr, which MCP clients typically surface to the user, so only
+warnings and errors appear by default. Use `--log-level info` for startup and
+connection lines. Clients that pass environment variables but not arguments can
+set `MCP_SAFARI_LOG_LEVEL` instead; an explicit flag takes precedence.
 
 Diagnose an installation without starting the MCP server:
 


### PR DESCRIPTION
Logs go to stderr, the only channel a stdio MCP server has, and clients surface it to the user. Every run printed its startup and connection lines at `info`, with no way to turn them down, only `--verbose` to turn them up.

Adds `--log-level trace|debug|info|notice|warning|error|critical` and an `MCP_SAFARI_LOG_LEVEL` environment variable, for clients that pass env but not argv. An explicit flag beats `--verbose`, which beats the environment. `--verbose` still means `debug`.

Lowers the default from `info` to `notice`, so warnings and errors still surface and routine lifecycle chatter doesn't.

Resolves #53