### PR TITLE
chore: prepare 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added `mcp-safari doctor` with human-readable and JSON output for installation, version, extension registration, and token checks.
+- Added a bridge-independent `status` MCP tool for listener, authentication, version, and token health.
+- Added a backward-compatible versioned extension/server handshake with explicit protocol mismatch errors.
+- Tool failures now include stable error codes, retry guidance, and recovery actions for disconnected bridges, stale element UIDs, missing targets, and wait timeouts.
+- `type_text` now supports opt-in native macOS keyboard events for contenteditable and framework-managed editors.
+- Added `upload_file` and `drop_file` for attaching explicit local files to a file input or dropping them onto an element.
+- Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
+- `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
+- `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries whose byte counts are withheld are marked `timingRestricted: true`.
+- `press_key`, `hover`, and `drag` now accept `native: true` for real macOS events, the same opt-in `type_text` already had: keys that trigger default actions such as focus moves and dialog dismissal, a pointer path that produces true CSS `:hover` and boundary events, and drags that threshold-based libraries accept. Character keys resolve against the active keyboard layout, so `Meta+a` is Command-A on AZERTY rather than Command-Q.
+
 ### Changed
 - Added `--log-level` and the `MCP_SAFARI_LOG_LEVEL` environment variable, and lowered the default from `info` to `notice`. Logs go to stderr, which MCP clients surface to the user, so routine startup and connection lines no longer appear unless asked for. `--verbose` is unchanged as a shorthand for `debug`.
 - Auth tokens are now written to `~/Library/Application Support/MCPSafari/tokens/<port>` in addition to the previous `~/.config/mcp-safari/tokens/<port>`, and the extension prefers the new location. A `~/.config` symlinked into a dotfiles repo resolves outside the sandboxed extension's read grant, which left the extension permanently disconnected with no diagnostic.
@@ -10,6 +22,7 @@
 - `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
 
 ### Bug Fixes
+- `run_steps` now accepts `upload_file` and `drop_file`, so a batch that attaches a file no longer has to be split around that step.
 - `click` and `hover` with `x`/`y` now dispatch events at the requested point instead of the target element's center, so a specific point inside a large element (e.g. a canvas) can be targeted.
 - `press_key` and `type_text`'s `submitKey` no longer emit `keypress` for keys that produce no character (Escape, Tab, arrow keys) or for Ctrl/Meta combos, matching the UI Events spec; single characters and Enter still fire it.
 - `hover` now dispatches the pointer-event family (`pointerover`/`pointerenter`/`pointermove`) alongside the mouse events in real pointer order, so Pointer Events handlers such as React's `onPointerEnter` run; accepts `x`/`y` coordinates like `click`; and reports that synthetic events never apply CSS `:hover`.
@@ -31,6 +44,10 @@
 - Fixed `snapshot` crashing on SVG elements with non-string `type` properties.
 - Retried trace startup once after an interceptor timeout so a transient `start_trace interceptor did not respond` failure no longer aborts the traced action.
 - `javascript_tool` now surfaces runtime throws and rejected promises as tool errors instead of returning `null`; the tool description documents that multi-statement code needs an explicit `return` to produce a value.
+- `read_network` with `clear` now removes only the entries the call returned, so a type- or URL-filtered clear no longer discards requests the caller never saw (matching `read_console`).
+- Stop stale per-port token files from causing endless extension reconnect attempts and popup state cycling.
+- Read the popup version from its manifest, keep ports ordered, and use adaptive system colors for legibility on Safari glass.
+- Reinject the content script when Safari returns no message-listener response instead of reporting a successful `null` result.
 
 ### Build
 - Updated SwiftPM dependencies, including MCP Swift SDK 0.12.1, SwiftLog 1.14.0, and SwiftNIO 2.101.3.
@@ -40,24 +57,6 @@
 - Added the Swift test suite to the main CI workflow.
 - Added weekly Dependabot updates for SwiftPM and GitHub Actions dependencies.
 - Fixed Swift package URLs generated by the OSV audit so dependency scans no longer fail with invalid requests.
-
-### Added
-- Added `mcp-safari doctor` with human-readable and JSON output for installation, version, extension registration, and token checks.
-- Added a bridge-independent `status` MCP tool for listener, authentication, version, and token health.
-- Added a backward-compatible versioned extension/server handshake with explicit protocol mismatch errors.
-- Tool failures now include stable error codes, retry guidance, and recovery actions for disconnected bridges, stale element UIDs, missing targets, and wait timeouts.
-- `type_text` now supports opt-in native macOS keyboard events for contenteditable and framework-managed editors.
-- Added `upload_file` and `drop_file` for attaching explicit local files to a file input or dropping them onto an element.
-- Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
-- `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
-- `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries whose byte counts are withheld are marked `timingRestricted: true`.
-- `press_key`, `hover`, and `drag` now accept `native: true` for real macOS events, the same opt-in `type_text` already had: keys that trigger default actions such as focus moves and dialog dismissal, a pointer path that produces true CSS `:hover` and boundary events, and drags that threshold-based libraries accept. Character keys resolve against the active keyboard layout, so `Meta+a` is Command-A on AZERTY rather than Command-Q.
-
-### Bug Fixes
-- `read_network` with `clear` now removes only the entries the call returned, so a type- or URL-filtered clear no longer discards requests the caller never saw (matching `read_console`).
-- Stop stale per-port token files from causing endless extension reconnect attempts and popup state cycling.
-- Read the popup version from its manifest, keep ports ordered, and use adaptive system colors for legibility on Safari glass.
-- Reinject the content script when Safari returns no message-listener response instead of reporting a successful `null` result.
 
 ## [0.2.9] - 2026-06-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.3.0] - 2026-08-25
 ### Added
 - Added `mcp-safari doctor` with human-readable and JSON output for installation, version, extension registration, and token checks.
 - Added a bridge-independent `status` MCP tool for listener, authentication, version, and token health.
@@ -50,7 +52,8 @@
 - Reinject the content script when Safari returns no message-listener response instead of reporting a successful `null` result.
 
 ### Build
-- Updated SwiftPM dependencies, including MCP Swift SDK 0.12.1, SwiftLog 1.14.0, and SwiftNIO 2.101.3.
+- Bumped app, extension, and server versions to `0.3.0`.
+- Updated SwiftPM dependencies, including MCP Swift SDK 0.12.1, SwiftLog 1.15.0, and SwiftNIO 2.101.3.
 - Updated CI and release builds to Xcode 26.6 and the latest supported major versions of their GitHub Actions.
 
 ### CI

--- a/MCPSafari/MCPSafari Extension/Resources/manifest.json
+++ b/MCPSafari/MCPSafari Extension/Resources/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "__MSG_extension_name__",
     "description": "__MSG_extension_description__",
-    "version": "0.2.9",
+    "version": "0.3.0",
 
     "icons": {
         "48": "images/icon-48.png",

--- a/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
+++ b/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -393,7 +393,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -414,7 +414,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -429,7 +429,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -572,7 +572,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -587,7 +587,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -613,7 +613,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -628,7 +628,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -652,11 +652,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -673,11 +673,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -693,10 +693,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -712,10 +712,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 30;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.2.9;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/MCPServer/Sources/mcp-safari/Diagnostics.swift
+++ b/MCPServer/Sources/mcp-safari/Diagnostics.swift
@@ -69,7 +69,7 @@ func parseCommand(
 let logLevelUsage = "Use trace, debug, info, notice, warning, error, or critical."
 
 enum MCPSafariProduct {
-    static let version = "0.2.9"
+    static let version = "0.3.0"
     static let bridgeProtocolVersion = 1
     static let extensionBundleIdentifier = "com.epistates.MCPSafari.Extension"
 }

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -15,6 +15,7 @@ struct RunStepsPlan: Equatable, Sendable {
     static let allowedTools: Set<String> = [
         "navigate", "click", "type_text", "form_input", "select_option",
         "press_key", "hover", "scroll", "drag", "wait",
+        "upload_file", "drop_file",
     ]
     static let maxSteps = 10
     static let maxTimeout = 60.0

--- a/MCPServer/Tests/MCPSafariTests/BridgeStatusTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/BridgeStatusTests.swift
@@ -17,10 +17,12 @@ struct BridgeStatusTests {
                 == .accept(.init(version: "0.2.9", protocolVersion: 1))
         )
 
-        let incompatible = Data(#"{"auth":"secret","extensionVersion":"0.3.0","protocolVersion":2}"#.utf8)
+        // Deliberately not a real release: the rejection turns on protocolVersion,
+        // and a shipped version number here reads as though that release is refused.
+        let incompatible = Data(#"{"auth":"secret","extensionVersion":"99.0.0","protocolVersion":2}"#.utf8)
         #expect(
             BridgeHandshake.decision(for: incompatible, expectedToken: "secret")
-                == .rejectProtocol(extensionVersion: "0.3.0", protocolVersion: 2)
+                == .rejectProtocol(extensionVersion: "99.0.0", protocolVersion: 2)
         )
 
         #expect(

--- a/MCPServer/Tests/MCPSafariTests/RunStepsTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/RunStepsTests.swift
@@ -20,6 +20,20 @@ struct RunStepsTests {
         #expect(plan.timeout == 60)
     }
 
+    @Test func acceptsTheFileAttachmentTools() throws {
+        // They route through the same handler a direct call does; excluding them
+        // forced callers to split a batch around the one step that attaches a file.
+        let plan = try RunStepsPlan(arguments: [
+            "steps": [
+                ["tool": "upload_file", "arguments": ["selector": "#file", "paths": ["/tmp/a.png"]]],
+                ["tool": "drop_file", "arguments": ["selector": "#drop", "paths": ["/tmp/b.png"]]],
+            ],
+        ])
+
+        #expect(plan.steps.map(\.tool) == ["upload_file", "drop_file"])
+        #expect(RunStepsPlan.allowedTools.isSuperset(of: ["upload_file", "drop_file"]))
+    }
+
     @Test func rejectsEmptyOversizedAndUnsupportedBatches() {
         #expect(errorMessage([:]) == "steps must contain at least one step")
         #expect(errorMessage(["steps": []]) == "steps must contain at least one step")


### PR DESCRIPTION
Release prep for 0.3.0. Three commits, reviewable separately.

Version bump to `0.3.0` across the server constant, the extension manifest, and all eight `MARKETING_VERSION` sites plus `CURRENT_PROJECT_VERSION` (29 to 30). `doctor` compares app and extension bundle versions against the server constant, so these have to move together. Verified with a Release `xcodebuild`: both bundles report `0.3.0`/`30` and the bundled `manifest.json` reads `0.3.0`.

Minor rather than patch because this adds tools (`native: true` for `press_key`/`hover`/`drag`, `type: "resource"` for `read_network`, `--log-level`) and changes two defaults: the log level drops from `info` to `notice`, and auth tokens move to `~/Library/Application Support/MCPSafari/tokens/<port>`.

`run_steps` now accepts `upload_file` and `drop_file`. They route through the same handler a direct call does, so excluding them only forced callers to split a batch around the step that attaches a file. Resolves #61.

CHANGELOG cleanup. `[Unreleased]` had two separate `### Bug Fixes` headings with `### Added` stranded between them. Regrouped into Added, Changed, Security, Bug Fixes, Build, CI with all 44 entries preserved, and dated as `[0.3.0]`.

Also stopped using `0.3.0` as the protocol-mismatch fixture in `BridgeStatusTests`, since that now names a real release and reads as though it's refused. The rejection turns on `protocolVersion`, not the version string.

Not tagging here. `v0.3.0` needs pushing separately once this lands, and the Homebrew tap update follows the release artifacts.