### PR TITLE
fix: fall back to the isolated world when page CSP blocks eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Bug Fixes
+- `javascript_tool` no longer fails outright on sites whose Content Security Policy omits `'unsafe-eval'`. Those pages refuse to compile a string in their own realm, which is how the tool runs submitted code; it now reruns in the extension's isolated world, where the DOM is shared but the page's own JavaScript globals are not, and says so in the result. When both worlds refuse, the error names the tools to use instead rather than surfacing the raw browser message.
 
 ## [0.3.0] - 2026-08-25
 ### Added

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -665,38 +665,73 @@ async function capturePageContext(tabId) {
 
 // ─── JavaScript Execution Handler ────────────────────────────────────
 
+// Injected into the target world, so it must not close over anything here.
+function evaluateUserCode(code) {
+    const describe = (e) => {
+        const message = e && e.message ? e.message : String(e);
+        // A page whose script-src omits 'unsafe-eval' refuses to compile a
+        // string in its own realm, which is what new Function does here.
+        const blocked = (typeof EvalError !== "undefined" && e instanceof EvalError)
+            || /unsafe-eval|trusted-types-eval|Content Security Policy/i.test(message);
+        return blocked ? { __error: message, __cspBlocked: true } : { __error: message };
+    };
+
+    try {
+        const expressionCode = String(code).trim().replace(/;+$/, "");
+        let fn;
+        try {
+            fn = new Function(`return (async () => (${expressionCode}))()`);
+        } catch (e) {
+            // A syntax error means it is not a bare expression; a CSP refusal
+            // means neither form will compile, so do not retry it as one.
+            if (typeof EvalError !== "undefined" && e instanceof EvalError) return describe(e);
+            fn = new Function(`return (async () => { ${code} })()`);
+        }
+        return fn().catch((e) => describe(e));
+    } catch (e) {
+        return describe(e);
+    }
+}
+
 async function handleJavaScript(params) {
     const tabId = params.tabId || (await getActiveTabId());
-    const results = await browser.scripting.executeScript({
-        target: { tabId },
-        func: (code) => {
-            try {
-                const expressionCode = String(code).trim().replace(/;+$/, "");
-                let fn;
-                try {
-                    fn = new Function(`return (async () => (${expressionCode}))()`);
-                } catch (_) {
-                    fn = new Function(`return (async () => { ${code} })()`);
-                }
-                return fn().catch((e) => ({
-                    __error: e && e.message ? e.message : String(e),
-                }));
-            } catch (e) {
-                return { __error: e.message };
-            }
-        },
-        args: [params.code],
-        world: "MAIN",
-    });
+    const runIn = async (world) => {
+        const results = await browser.scripting.executeScript({
+            target: { tabId },
+            func: evaluateUserCode,
+            args: [params.code],
+            world,
+        });
+        return results && results.length > 0 ? results[0].result : undefined;
+    };
 
-    if (results && results.length > 0) {
-        const result = results[0].result;
-        if (result && result.__error) {
-            throw new Error(result.__error);
+    let result = await runIn("MAIN");
+    let isolated = false;
+
+    if (result && result.__cspBlocked) {
+        // The isolated world does not inherit the page's CSP and still shares
+        // the DOM, so DOM-based code survives a strict script-src. Page
+        // JavaScript globals do not exist there, which the caller is told.
+        // Retrying is safe because a CSP refusal happens at compile time, so
+        // nothing in the submitted code has run yet and side effects cannot double.
+        const fallback = await runIn("ISOLATED");
+        if (fallback && fallback.__cspBlocked) {
+            throw new Error(
+                "The page's Content Security Policy blocks evaluating code as a string, "
+                + "in both the page world and the extension's isolated world. "
+                + "Use snapshot, find, or read_page to inspect the page, and click or "
+                + "type_text to drive it."
+            );
         }
-        return result !== undefined ? JSON.stringify(result) : "undefined";
+        result = fallback;
+        isolated = true;
     }
-    return "undefined";
+
+    if (result && result.__error) throw new Error(result.__error);
+    const value = result !== undefined ? JSON.stringify(result) : "undefined";
+    return isolated
+        ? `${value}\n\n[Ran in the extension's isolated world: the page's CSP blocked evaluation in the page world. The DOM is shared, but page JavaScript globals such as window properties set by the site are not visible.]`
+        : value;
 }
 
 // ─── Window Resize Handler ───────────────────────────────────────────

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -483,7 +483,7 @@ actor SafariMCPServer {
             ),
             Tool(
                 name: "javascript_tool",
-                description: "Execute JS in page context. A single expression returns its value; a multi-statement body must end in an explicit `return` to produce a value.",
+                description: "Execute JS in page context. A single expression returns its value; a multi-statement body must end in an explicit `return` to produce a value. If the page's Content Security Policy forbids evaluating strings, this reruns in the extension's isolated world, where the DOM is shared but the page's own JavaScript globals are not visible; the result says so when that happens.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 |------|-------------|
 | `javascript_tool` | Execute arbitrary JS in the page context and return expression results; multi-statement code must end in an explicit `return` to produce a value |
 
+> **Note:** Sites whose Content Security Policy omits `'unsafe-eval'` refuse to compile a string in their own realm, which is how this tool runs your code. When that happens it reruns in the extension's isolated world and says so in the result. The DOM is shared there, so querying and manipulating the page still works, but the site's own JavaScript globals (framework instances, anything the page assigned to `window`) are not visible. Retrying is safe — a CSP refusal happens before any of the submitted code runs.
+
 ### Debugging
 
 | Tool | Description |

--- a/Tests/background-javascript.test.mjs
+++ b/Tests/background-javascript.test.mjs
@@ -8,7 +8,20 @@ const backgroundSource = readFileSync(
     "utf8"
 );
 
-function backgroundHarness() {
+// Built inside the vm so the thrown EvalError belongs to that realm, the way a
+// real page's refusal does; a cross-realm one would defeat `instanceof`.
+function refusingFunction(context) {
+    return vm.runInContext(
+        `(function () {
+            throw new EvalError("Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: \\"script-src 'self'\\".");
+        })`,
+        context
+    );
+}
+
+function backgroundHarness({ cspBlockedWorlds = [] } = {}) {
+    let context;
+
     class FakeWebSocket {
         static CONNECTING = 0;
         constructor(url) {
@@ -29,7 +42,23 @@ function backgroundHarness() {
             sendNativeMessage: async () => ({ tokens: {} }),
         },
         scripting: {
-            executeScript: async ({ func, args }) => [{ result: await func(...args) }],
+            // A world whose CSP forbids 'unsafe-eval' refuses to compile a
+            // string, which is what `new Function` does inside the injected code.
+            executeScript: async ({ func, args, world }) => {
+                if (!cspBlockedWorlds.includes(world)) {
+                    return [{ result: await func(...args) }];
+                }
+                // Read from inside: intrinsics live on the vm global, not on the
+                // sandbox object, so `context.Function` here would be undefined
+                // and restoring it would erase the real one.
+                const realFunction = vm.runInContext("Function", context);
+                context.Function = refusingFunction(context);
+                try {
+                    return [{ result: await func(...args) }];
+                } finally {
+                    context.Function = realFunction;
+                }
+            },
         },
         storage: {
             local: { get: async () => ({}), set() {} },
@@ -41,7 +70,7 @@ function backgroundHarness() {
         },
     };
 
-    const context = vm.createContext({
+    context = vm.createContext({
         browser,
         clearTimeout() {},
         console: { error() {}, log() {}, warn() {} },
@@ -100,4 +129,30 @@ test("async IIFE expression keeps working", async () => {
     const run = backgroundHarness();
     const code = "(async () => { const a = await Promise.resolve(41); return JSON.stringify({ b: a + 1 }) })()";
     assert.equal(await run(code), '"{\\"b\\":42}"');
+});
+
+test("a page CSP that blocks eval falls back to the isolated world", async () => {
+    const run = backgroundHarness({ cspBlockedWorlds: ["MAIN"] });
+
+    const output = await run("1 + 1");
+
+    assert.match(output, /^2\n/, "the value still comes back");
+    assert.match(output, /isolated world/i, "and the caller is told where it ran");
+    assert.match(output, /globals/i, "including what is not visible there");
+});
+
+test("CSP in both worlds reports what to use instead", async () => {
+    const run = backgroundHarness({ cspBlockedWorlds: ["MAIN", "ISOLATED"] });
+
+    await assert.rejects(run("1 + 1"), (err) => {
+        assert.match(err.message, /Content Security Policy/);
+        assert.match(err.message, /snapshot|find|read_page/);
+        assert.doesNotMatch(err.message, /unsafe-eval/, "the raw browser text is replaced with guidance");
+        return true;
+    });
+});
+
+test("an ordinary page still runs in the page world with no note", async () => {
+    const run = backgroundHarness();
+    assert.equal(await run("1 + 1"), "2");
 });


### PR DESCRIPTION
`javascript_tool` injects into `world: "MAIN"` and calls `new Function`. That compiles a string in the page's own realm, so it obeys the page's Content Security Policy: a site whose `script-src` omits `'unsafe-eval'` refuses it, and the tool failed with the raw browser message.

Retries in the extension's isolated world, which doesn't inherit the page CSP and still shares the DOM. Querying and manipulating the page keeps working. The site's own JavaScript globals aren't visible there, so the result says so rather than letting `window.someAppGlobal` come back `undefined` and read as a real answer.

The retry can't double side effects, since a CSP refusal happens at compile time before any of the submitted code runs. When both worlds refuse, the error names `snapshot`, `find` and `read_page` instead of surfacing the raw browser text.

Also stops retrying the statement-body form after a refusal. That fallback exists for "this isn't a bare expression", and a refusal means neither form will compile.

Resolves #63