### PR TITLE
fix: drop uid entries when their element is collected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `snapshot` no longer reports the contents of password inputs, or of inputs whose `autocomplete` marks them as a one-time code or payment card field; those values come back as `[redacted]`.
 
 ### Bug Fixes
+- Element UIDs are now dropped once their element is collected. The reverse lookup held a uid and a `WeakRef` per element for the life of the page, so a long session re-snapshotting a page that re-renders grew it without bound.
 - `javascript_tool` no longer fails outright on sites whose Content Security Policy omits `'unsafe-eval'`. Those pages refuse to compile a string in their own realm, which is how the tool runs submitted code, so it now reruns in the extension's isolated world, where the DOM is shared but the page's own JavaScript globals are not, and says so in the result. When both worlds refuse, the error names the tools to use instead of surfacing the raw browser message.
 - `run_steps` now accepts `upload_file` and `drop_file`, so a batch that attaches a file no longer has to be split around that step.
 - `click` and `hover` with `x`/`y` now dispatch events at the requested point instead of the target element's center, so a specific point inside a large element (e.g. a canvas) can be targeted.

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -37,17 +37,28 @@
         return String(value).replace(/["\\]/g, "\\$&");
     }
 
+    // The WeakRef lets the element go, but its entry here would outlive it.
+    // A long agent session re-snapshotting a page that re-renders mints a fresh
+    // uid every time, so without this the map grows for the life of the page.
+    const uidFinalizer = typeof FinalizationRegistry === "function"
+        ? new FinalizationRegistry((uid) => { reverseUidMap.delete(uid); })
+        : null;
+
     function getUid(element) {
         if (uidMap.has(element)) return uidMap.get(element);
         const uid = `e${++uidCounter}`;
         uidMap.set(element, uid);
         reverseUidMap.set(uid, new WeakRef(element));
+        if (uidFinalizer) uidFinalizer.register(element, uid);
         return uid;
     }
 
     function getElementByUid(uid) {
         const ref = reverseUidMap.get(uid);
-        return ref ? ref.deref() : null;
+        const element = ref ? ref.deref() : null;
+        // Collection may have happened without the finalizer having run yet.
+        if (ref && !element) reverseUidMap.delete(uid);
+        return element;
     }
 
     function requestMainWorld(type, params = {}, timeoutMs = 3000) {

--- a/Tests/content-uid-lifecycle.test.mjs
+++ b/Tests/content-uid-lifecycle.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+
+function el(tag, id) {
+    const node = {
+        nodeType: ELEMENT_NODE,
+        tagName: tag.toUpperCase(),
+        attributes: {},
+        hidden: false,
+        id: id || "",
+        childNodes: [],
+        textContent: "",
+        getAttribute: () => null,
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 10, height: 10 }),
+        scrollIntoView() {},
+        focus() {},
+        dispatchEvent() { return true; },
+    };
+    Object.defineProperty(node, "children", {
+        get: () => node.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    return node;
+}
+
+// Drives collection by hand: nothing here is left to a real GC.
+function loadContent(body) {
+    let listener;
+    const registrations = [];
+    let finalizerCallback;
+    const collected = new Set();
+
+    class ControlledWeakRef {
+        constructor(target) { this.target = target; }
+        deref() { return collected.has(this.target) ? undefined : this.target; }
+    }
+
+    class ControlledFinalizationRegistry {
+        constructor(callback) { finalizerCallback = callback; }
+        register(target, token) { registrations.push({ target, token }); }
+    }
+
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document: {
+            body,
+            documentElement: body,
+            activeElement: null,
+            getElementById: () => null,
+            querySelector: () => null,
+            querySelectorAll: () => [],
+            createTreeWalker(root, _show, filter) {
+                const queue = [...root.childNodes];
+                return {
+                    nextNode() {
+                        while (queue.length) {
+                            const n = queue.shift();
+                            if (filter.acceptNode(n) === 1) return n;
+                        }
+                        return null;
+                    },
+                };
+            },
+        },
+        Node: { ELEMENT_NODE, TEXT_NODE: 3 },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef: ControlledWeakRef,
+        FinalizationRegistry: ControlledFinalizationRegistry,
+        setTimeout,
+        clearTimeout,
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            postMessage: () => {},
+            innerHeight: 800,
+            getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+        },
+    });
+
+    return {
+        call: (action, params) => new Promise((r) => listener({ action, params }, {}, r)),
+        registrations,
+        collect: (node) => collected.add(node),
+        runFinalizer: (token) => finalizerCallback(token),
+    };
+}
+
+const uidFor = (registrations, node) =>
+    registrations.find((r) => r.target === node)?.token;
+
+test("every minted uid is registered for cleanup", async () => {
+    const first = el("button");
+    const second = el("button");
+    const body = el("body");
+    body.childNodes = [first, second];
+    const { call, registrations } = loadContent(body);
+
+    await call("snapshot", {});
+
+    // Registered against the element, so the token is dropped when it goes.
+    assert.equal(registrations.length, 3, "body and both buttons");
+    for (const node of [body, first, second]) {
+        assert.match(uidFor(registrations, node) ?? "", /^e\d+$/);
+    }
+});
+
+test("a uid whose element was collected stops resolving", async () => {
+    const button = el("button");
+    const body = el("body");
+    body.childNodes = [button];
+    const { call, registrations, collect, runFinalizer } = loadContent(body);
+
+    await call("snapshot", {});
+    const uid = uidFor(registrations, button);
+
+    collect(button);
+    runFinalizer(uid);
+
+    const response = await call("click", { uid });
+    assert.equal(response.errorCode, "stale_uid");
+});
+
+test("a collected element is swept on read even before the finalizer runs", async () => {
+    // Finalization is not prompt, so the read path cannot assume it has happened.
+    const button = el("button");
+    const body = el("body");
+    body.childNodes = [button];
+    const { call, registrations, collect } = loadContent(body);
+
+    await call("snapshot", {});
+    const uid = uidFor(registrations, button);
+
+    collect(button);
+
+    const response = await call("click", { uid });
+    assert.equal(response.errorCode, "stale_uid");
+});


### PR DESCRIPTION
`reverseUidMap` held a uid and a `WeakRef` per element forever. The `WeakRef` let the element go, but the entry outlived it, and a long session re-snapshotting a page that re-renders mints a fresh uid every time, so the map grew for the life of the page.

Registers each element with a `FinalizationRegistry` keyed by its uid, and sweeps on read too, since finalization isn't prompt.

CHANGELOG entry follows once #66 lands, to avoid both touching the same hunk.

Resolves #60