### PR TITLE
feat: cap snapshot node count and read_page character count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `run_steps` for bounded sequential interaction and wait batches with ordered results, first-failure stopping, one optional trace, and one optional final snapshot.
 - `screenshot` now reports the viewport size, device pixel ratio, page visibility, and window focus at capture time, so callers can tell device pixels from CSS pixels and can detect a frame captured while Safari was neither repainting the page nor applying `:focus`.
 - `read_network` now accepts `type: "resource"` to report PerformanceResourceTiming entries without changing the default XHR/fetch feed, plus `urlPattern` (regex) and `maxResults` filters on any feed and a `status` filter on the XHR/fetch feed. Cross-origin resource entries whose byte counts are withheld are marked `timingRestricted: true`.
+- `snapshot` is capped at 2000 nodes and accepts `maxNodes`; a cut tree marks the root `truncated` and each parent whose children were dropped `childrenTruncated`, so a clipped snapshot is distinguishable from a complete one. `read_page` text and html are capped at 100000 characters, accept `maxChars`, and report the full size when they cut.
 - `press_key`, `hover`, and `drag` now accept `native: true` for real macOS events, the same opt-in `type_text` already had: keys that trigger default actions such as focus moves and dialog dismissal, a pointer path that produces true CSS `:hover` and boundary events, and drags that threshold-based libraries accept. Character keys resolve against the active keyboard layout, so `Meta+a` is Command-A on AZERTY rather than Command-Q.
 
 ### Changed

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -120,7 +120,7 @@
             case "get_page_text":
                 return getPageText();
             case "snapshot":
-                return takeSnapshot();
+                return takeSnapshot(params);
             case "find":
                 return findElements(params);
             case "click":
@@ -168,15 +168,29 @@
 
     // ─── Page Reading ────────────────────────────────────────────────
 
+    // A big application page runs to hundreds of kilobytes, which either
+    // overruns the client's output limit or spends the model's context on one
+    // call. Cut it and say so, rather than returning a clipped page that reads
+    // like the whole thing.
+    const MAX_PAGE_CHARS = 100000;
+
+    function clampText(value, limit) {
+        const max = limit > 0 ? limit : MAX_PAGE_CHARS;
+        if (value.length <= max) return value;
+        return `${value.slice(0, max)}\n\n[truncated: ${value.length} characters total, `
+            + `${max} returned. Raise maxChars, or use find or snapshot to target a region.]`;
+    }
+
     function readPage(params) {
         const format = params.format || "text";
+        const maxChars = Number(params.maxChars) > 0 ? Number(params.maxChars) : 0;
         switch (format) {
             case "html":
-                return document.documentElement.outerHTML;
+                return clampText(document.documentElement.outerHTML, maxChars);
             case "text":
-                return document.body ? document.body.innerText : "";
+                return clampText(document.body ? document.body.innerText : "", maxChars);
             case "snapshot":
-                return takeSnapshot();
+                return takeSnapshot(params);
             default:
                 throw new Error(`Unknown format: ${format}. Use 'text', 'html', or 'snapshot'.`);
         }
@@ -189,15 +203,27 @@
     // ─── Accessibility Snapshot ──────────────────────────────────────
 
     const MAX_TREE_DEPTH = 30;
+    const MAX_SNAPSHOT_NODES = 2000;
 
-    function takeSnapshot() {
+    function takeSnapshot(params = {}) {
         const root = document.body || document.documentElement;
-        return buildTree(root, 0);
+        const requested = Number(params.maxNodes);
+        const budget = { remaining: requested > 0 ? requested : MAX_SNAPSHOT_NODES, cut: false };
+        const tree = buildTree(root, 0, budget);
+        // Marked on the root as well, so a caller reading the top of a large
+        // tree can tell a cut snapshot from a complete one without scanning it.
+        if (tree && budget.cut) tree.truncated = true;
+        return tree;
     }
 
-    function buildTree(element, depth) {
+    function buildTree(element, depth, budget) {
         if (depth > MAX_TREE_DEPTH) return null;
         if (!isVisible(element)) return null;
+        if (budget.remaining <= 0) {
+            budget.cut = true;
+            return null;
+        }
+        budget.remaining -= 1;
 
         const role = getRole(element);
         const name = getAccessibleName(element);
@@ -229,10 +255,13 @@
 
         // Children
         const children = [];
+        let droppedChildren = false;
         for (const child of element.children) {
-            const childNode = buildTree(child, depth + 1);
+            const childNode = buildTree(child, depth + 1, budget);
             if (childNode) children.push(childNode);
+            else if (budget.remaining <= 0) droppedChildren = true;
         }
+        if (droppedChildren) node.childrenTruncated = true;
 
         // Leaf nodes report their whole text content. Nodes that also have
         // element children report their own direct text nodes, so mixed

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -271,20 +271,34 @@ actor SafariMCPServer {
 
             Tool(
                 name: "snapshot",
-                description: "Accessibility tree with element UIDs for interaction tools. UIDs change between snapshots.",
+                description: "Accessibility tree with element UIDs for interaction tools. UIDs change between snapshots. Capped at 2000 nodes by default; a cut tree marks the root `truncated` and each parent whose children were dropped `childrenTruncated`.",
                 inputSchema: .object([
                     "type": .string("object"),
-                    "properties": .object(["tabId": Self.tab]),
+                    "properties": .object([
+                        "maxNodes": .object([
+                            "type": .string("integer"),
+                            "description": .string("Maximum nodes to return (default 2000)"),
+                        ]),
+                        "tabId": Self.tab,
+                    ]),
                 ]),
                 annotations: .init(readOnlyHint: true)
             ),
             Tool(
                 name: "read_page",
-                description: "Page content as text, html, or snapshot.",
+                description: "Page content as text, html, or snapshot. Text and html are capped at 100000 characters by default and say so when cut; snapshot takes maxNodes.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
                         "format": .object(["type": .string("string"), "enum": .array([.string("text"), .string("html"), .string("snapshot")])]),
+                        "maxChars": .object([
+                            "type": .string("integer"),
+                            "description": .string("Character cap for text and html (default 100000)"),
+                        ]),
+                        "maxNodes": .object([
+                            "type": .string("integer"),
+                            "description": .string("Node cap when format is snapshot (default 2000)"),
+                        ]),
                         "tabId": Self.tab,
                     ]),
                 ]),
@@ -743,6 +757,28 @@ actor SafariMCPServer {
             }
             params["format"] = AnyCodable(format)
         }
+        if let maxChars = args["maxChars"]?.intValue {
+            guard maxChars > 0 else {
+                return Self.failureResult(ToolFailure(
+                    code: "invalid_input",
+                    message: "Invalid maxChars: \(maxChars). Use a positive integer.",
+                    retryable: false,
+                    recoveryAction: "fix_input"
+                ))
+            }
+            params["maxChars"] = AnyCodable(maxChars)
+        }
+        if let maxNodes = args["maxNodes"]?.intValue {
+            guard maxNodes > 0 else {
+                return Self.failureResult(ToolFailure(
+                    code: "invalid_input",
+                    message: "Invalid maxNodes: \(maxNodes). Use a positive integer.",
+                    retryable: false,
+                    recoveryAction: "fix_input"
+                ))
+            }
+            params["maxNodes"] = AnyCodable(maxNodes)
+        }
         let response = try await bridge.send(action: "read_page", params: params)
         return textResult(response)
     }
@@ -750,6 +786,17 @@ actor SafariMCPServer {
     private func handleSnapshot(_ args: [String: Value]) async throws -> CallTool.Result {
         var params: [String: AnyCodable] = [:]
         if let tabId = args["tabId"]?.intValue { params["tabId"] = AnyCodable(tabId) }
+        if let maxNodes = args["maxNodes"]?.intValue {
+            guard maxNodes > 0 else {
+                return Self.failureResult(ToolFailure(
+                    code: "invalid_input",
+                    message: "Invalid maxNodes: \(maxNodes). Use a positive integer.",
+                    retryable: false,
+                    recoveryAction: "fix_input"
+                ))
+            }
+            params["maxNodes"] = AnyCodable(maxNodes)
+        }
         let response = try await bridge.send(action: "snapshot", params: params)
         return textResult(response)
     }

--- a/Tests/content-output-caps.test.mjs
+++ b/Tests/content-output-caps.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+
+function el(tag, id) {
+    const node = {
+        nodeType: ELEMENT_NODE,
+        tagName: tag.toUpperCase(),
+        attributes: {},
+        hidden: false,
+        id: id || "",
+        childNodes: [],
+        textContent: "",
+        getAttribute: () => null,
+        getBoundingClientRect: () => ({ x: 0, y: 0, width: 10, height: 10 }),
+        scrollIntoView() {},
+        focus() {},
+        dispatchEvent() { return true; },
+    };
+    Object.defineProperty(node, "children", {
+        get: () => node.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    return node;
+}
+
+function loadContent(body) {
+    let listener;
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document: {
+            body,
+            documentElement: body,
+            activeElement: null,
+            getElementById: () => null,
+            querySelector: () => null,
+            querySelectorAll: () => [],
+            createTreeWalker(root, _show, filter) {
+                const queue = [...root.childNodes];
+                return {
+                    nextNode() {
+                        while (queue.length) {
+                            const n = queue.shift();
+                            if (filter.acceptNode(n) === 1) return n;
+                        }
+                        return null;
+                    },
+                };
+            },
+        },
+        Node: { ELEMENT_NODE, TEXT_NODE: 3 },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            postMessage: () => {},
+            innerHeight: 800,
+            getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+        },
+    });
+
+    return { call: (action, params) => new Promise((r) => listener({ action, params }, {}, r)) };
+}
+
+function tree(width) {
+    const body = el("body");
+    body.childNodes = Array.from({ length: width }, () => el("button"));
+    return body;
+}
+
+test("snapshot stops at maxNodes and marks where it cut", async () => {
+    const { call } = loadContent(tree(10));
+
+    const { data } = await call("snapshot", { maxNodes: 4 });
+
+    assert.equal(data.truncated, true, "the root says the tree is incomplete");
+    assert.equal(data.childrenTruncated, true, "and the parent whose children were dropped says so");
+    assert.equal(data.children.length, 3, "root plus three children fills a budget of four");
+});
+
+test("a tree inside the budget is not marked", async () => {
+    const { call } = loadContent(tree(3));
+
+    const { data } = await call("snapshot", { maxNodes: 100 });
+
+    assert.equal(data.truncated, undefined);
+    assert.equal(data.childrenTruncated, undefined);
+    assert.equal(data.children.length, 3);
+});
+
+test("read_page text is capped and reports the full size", async () => {
+    const body = el("body");
+    body.innerText = "x".repeat(500);
+    const { call } = loadContent(body);
+
+    const { data } = await call("read_page", { format: "text", maxChars: 100 });
+
+    assert.equal(data.slice(0, 100), "x".repeat(100));
+    assert.match(data, /truncated: 500 characters total, 100 returned/);
+    assert.match(data, /find or snapshot/, "and points at a way to get less");
+});
+
+test("read_page text under the cap comes back whole", async () => {
+    const body = el("body");
+    body.innerText = "short page";
+    const { call } = loadContent(body);
+
+    const { data } = await call("read_page", { format: "text", maxChars: 100 });
+
+    assert.equal(data, "short page");
+});


### PR DESCRIPTION
Neither `snapshot` nor `read_page` bounded what it returned, so a large application page came back as hundreds of kilobytes in one tool result. That either overruns the client's output limit or spends a large share of the model's context on a single call, and the caller had no way to ask for less.

`snapshot` stops at 2000 nodes and takes `maxNodes`. A cut tree marks the root `truncated` and each parent whose children were dropped `childrenTruncated`, so a clipped snapshot is distinguishable from a complete one rather than silently looking like the whole page.

`read_page` text and html stop at 100000 characters, take `maxChars`, and report the full size when they cut.

Stacked on #67. CHANGELOG entries for both follow once #66 lands.

Resolves #59