### PR TITLE
feat: screenshot filePath saves the PNG to disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- `screenshot` accepts `filePath`: the PNG is written there and the result carries the path and byte count instead of inline image data, so batch captures no longer flood the client context.
+
 ### Security
 - `tabs_context`, `tabs_create`, `select_tab`, and `navigate` now return tab URLs with the values of `access_token`, `id_token`, `refresh_token`, `client_secret`, `api_key`, and `password` replaced by `[redacted]`; `code` is redacted when the URL also carries an OAuth `state`.
 

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -488,12 +488,15 @@ actor SafariMCPServer {
 
             Tool(
                 name: "screenshot",
-                description: "Capture visible tab as PNG.",
+                description: "Capture visible tab as PNG. Pass filePath to save the PNG to disk and get the path back instead of inline image data.",
                 inputSchema: .object([
                     "type": .string("object"),
-                    "properties": .object(["tabId": Self.tab]),
+                    "properties": .object([
+                        "filePath": .object(["type": .string("string"), "description": .string("Save the PNG to this local path (~ expanded) and return the path instead of the image")]),
+                        "tabId": Self.tab,
+                    ]),
                 ]),
-                annotations: .init(readOnlyHint: true)
+                annotations: .init(readOnlyHint: false)
             ),
             Tool(
                 name: "javascript_tool",
@@ -1506,14 +1509,54 @@ actor SafariMCPServer {
         if let failure = Self.captureFailure(imageData) {
             return Self.failureResult(failure)
         }
+        let note = capture.flatMap(Self.captureNote)
+
+        if let filePath = args["filePath"], let png = Data(base64Encoded: imageData) {
+            let url: URL
+            do {
+                guard let path = filePath.stringValue else { throw FileAttachmentError("filePath must be a string") }
+                url = try Self.writeCapture(png, to: path)
+            } catch {
+                return Self.failureResult(ToolFailure(
+                    code: "invalid_input",
+                    message: "\(error)",
+                    retryable: false,
+                    recoveryAction: "fix_input"
+                ))
+            }
+            let text = ["Saved PNG to \(url.path) (\(png.count) bytes).", note]
+                .compactMap { $0 }
+                .joined(separator: "\n")
+            return CallTool.Result(content: [Self.textContent(text)])
+        }
 
         var content: [Tool.Content] = [
             Self.imageContent(data: imageData, mimeType: "image/png"),
         ]
-        if let capture, let note = Self.captureNote(capture) {
+        if let note {
             content.append(Self.textContent(note))
         }
         return CallTool.Result(content: content)
+    }
+
+    /// Writes a capture to the caller's path. A batch of full-resolution frames
+    /// does not fit through the client inline, and only the server can reach
+    /// the filesystem, so the write happens here rather than in the extension.
+    static func writeCapture(_ png: Data, to path: String) throws -> URL {
+        guard !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FileAttachmentError("filePath must not be empty")
+        }
+        let url = URL(fileURLWithPath: (path as NSString).expandingTildeInPath).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            throw FileAttachmentError("filePath is a directory, not a file: \(url.path)")
+        }
+        do {
+            try png.write(to: url, options: .atomic)
+        } catch {
+            throw FileAttachmentError("Cannot write screenshot to \(url.path) (\(error.localizedDescription))")
+        }
+        return url
     }
 
     /// Safari resolves a failed capture to an empty or non-image payload, and

--- a/MCPServer/Tests/MCPSafariTests/ScreenshotContextTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/ScreenshotContextTests.swift
@@ -75,6 +75,48 @@ struct ScreenshotContextTests {
         #expect(SafariMCPServer.decodeCapture("iVBORw0KGgoAAAANSUhEUg==") == nil)
     }
 
+    @Test func writeCaptureSavesBytesToTheRequestedPath() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcp-safari-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let png = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3])
+        let url = try SafariMCPServer.writeCapture(png, to: root.appendingPathComponent("shot.png").path)
+
+        #expect(url.lastPathComponent == "shot.png")
+        #expect(try Data(contentsOf: url) == png)
+
+        // A second capture to the same path replaces the first frame.
+        let next = Data([0x89, 0x50, 0x4E, 0x47, 9])
+        _ = try SafariMCPServer.writeCapture(next, to: url.path)
+        #expect(try Data(contentsOf: url) == next)
+
+        // A trailing space is part of the filename, not something to strip
+        // before picking the destination.
+        let spaced = try SafariMCPServer.writeCapture(png, to: url.path + " ")
+        #expect(spaced.lastPathComponent == "shot.png ")
+        #expect(try Data(contentsOf: url) == next)
+    }
+
+    @Test func writeCaptureRejectsEmptyDirectoryAndUnwritablePaths() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mcp-safari-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let png = Data([0x89, 0x50, 0x4E, 0x47])
+        #expect(throws: FileAttachmentError.self) {
+            try SafariMCPServer.writeCapture(png, to: "   ")
+        }
+        #expect(throws: FileAttachmentError.self) {
+            try SafariMCPServer.writeCapture(png, to: root.path)
+        }
+        #expect(throws: FileAttachmentError.self) {
+            try SafariMCPServer.writeCapture(png, to: root.appendingPathComponent("missing/dir/shot.png").path)
+        }
+    }
+
     @Test func captureFailureAcceptsDecodableImageData() throws {
         #expect(SafariMCPServer.captureFailure("iVBORw0KGgoAAAANSUhEUg==") == nil)
     }

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 
 | Tool | Description |
 |------|-------------|
-| `screenshot` | Capture the visible tab area as a PNG image, with viewport, scale, page visibility, and window focus |
+| `screenshot` | Capture the visible tab area as a PNG image, with viewport, scale, page visibility, and window focus; `filePath` saves it to disk and returns the path instead of inline image data |
 
 ### JavaScript
 


### PR DESCRIPTION
## Problem

`screenshot` only returns inline image content. A 3200x2020 capture is 5,029,348 PNG bytes, 6.7 M base64 chars on one stdio frame; a 99-slide deck capture had to drop to `screencapture` in bash because the loop could not stay in MCP.

## Fix

Optional `filePath` on `screenshot`. The server decodes the PNG the extension already sends, writes it atomically to the path (`~` expanded), and returns `Saved PNG to <path> (<bytes> bytes).` with the usual capture note instead of the image. Empty, non-string, directory, or unwritable paths return `invalid_input`. `readOnlyHint` is now `false` because the tool can overwrite a file. Extension untouched; without `filePath` nothing changes.

## Validation

- `swift test`: 52/52 (2 new in `ScreenshotContextTests`)
- `node --test Tests/*.mjs`: 97/97
- `tools/list` on the release binary shows the new parameter
