### PR TITLE
fix: click dispatches pointer events so pointerdown-driven controls open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Security
 - `tabs_context`, `tabs_create`, `select_tab`, and `navigate` now return tab URLs with the values of `access_token`, `id_token`, `refresh_token`, `client_secret`, `api_key`, and `password` replaced by `[redacted]`; `code` is redacted when the URL also carries an OAuth `state`.
 
+### Bug Fixes
+- `click` now dispatches `pointerdown`/`pointerup` ahead of `mousedown`/`mouseup`, and skips the mouse press and focus change when a handler cancels `pointerdown`, matching real input. Pointer-driven toggles such as Radix `DropdownMenu` triggers open instead of reporting a successful click that changed nothing.
+
 ## [0.3.0] - 2026-08-28
 ### Added
 - Added `mcp-safari doctor` with human-readable and JSON output for installation, version, extension registration, and token checks.

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -661,18 +661,31 @@
             view: window,
             clientX: x,
             clientY: y,
+            button: 0,
+            buttons: 0,
+        };
+        const pointerOpts = { ...eventOpts, pointerId: 1, pointerType: "mouse", isPrimary: true };
+
+        // Real pointer order: pointer family first. Cancelling pointerdown
+        // suppresses the compatibility mouse events and the focus change, which
+        // is how pointer-driven toggles (Radix, Headless UI) keep a click from
+        // re-toggling what pointerdown just opened.
+        const press = () => {
+            const pressed = element.dispatchEvent(pointerEvent("pointerdown", { ...pointerOpts, buttons: 1 }));
+            if (pressed && element.dispatchEvent(new MouseEvent("mousedown", { ...eventOpts, buttons: 1 }))) {
+                element.focus();
+            }
+            element.dispatchEvent(pointerEvent("pointerup", pointerOpts));
+            if (pressed) element.dispatchEvent(new MouseEvent("mouseup", eventOpts));
+            element.dispatchEvent(new MouseEvent("click", eventOpts));
         };
 
+        element.dispatchEvent(pointerEvent("pointerover", pointerOpts));
         element.dispatchEvent(new MouseEvent("mouseover", eventOpts));
-        element.dispatchEvent(new MouseEvent("mousedown", eventOpts));
-        element.focus();
-        element.dispatchEvent(new MouseEvent("mouseup", eventOpts));
-        element.dispatchEvent(new MouseEvent("click", eventOpts));
+        press();
 
         if (doubleClick) {
-            element.dispatchEvent(new MouseEvent("mousedown", eventOpts));
-            element.dispatchEvent(new MouseEvent("mouseup", eventOpts));
-            element.dispatchEvent(new MouseEvent("click", eventOpts));
+            press();
             element.dispatchEvent(new MouseEvent("dblclick", eventOpts));
         }
     }

--- a/Tests/content-click-pointer.test.mjs
+++ b/Tests/content-click-pointer.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+class FakeMouseEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        Object.assign(this, options);
+    }
+}
+class FakePointerEvent extends FakeMouseEvent {}
+
+// A button that behaves like a Radix DropdownMenu trigger when `cancelsPointerDown`
+// is set: it toggles on pointerdown and cancels it, so a real browser would not
+// deliver mousedown/mouseup or move focus.
+function loadClick({ cancelsPointerDown = false, cancelsMouseDown = false } = {}) {
+    const seen = [];
+    let focused = 0;
+    let open = false;
+    const target = {
+        nodeType: 1,
+        tagName: "BUTTON",
+        hidden: false,
+        textContent: "Account menu",
+        scrollIntoView() {},
+        getBoundingClientRect: () => ({ x: 0, y: 0, left: 0, top: 0, width: 300, height: 100 }),
+        focus() { focused += 1; },
+        dispatchEvent(event) {
+            seen.push(`${event instanceof FakePointerEvent ? "P" : "M"}:${event.type}`);
+            if (event.type === "pointerdown" && cancelsPointerDown) {
+                open = !open;
+                return false;
+            }
+            return !(event.type === "mousedown" && cancelsMouseDown);
+        },
+    };
+    let listener;
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document: { body: null, documentElement: null, activeElement: null, querySelector: () => target },
+        Node: { ELEMENT_NODE: 1, TEXT_NODE: 3 },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        MouseEvent: FakeMouseEvent,
+        PointerEvent: FakePointerEvent,
+        window: { addEventListener() {}, removeEventListener() {} },
+    });
+    const call = (action, params) => new Promise((r) => listener({ action, params }, {}, r));
+    return { call, seen, focused: () => focused, open: () => open };
+}
+
+test("click dispatches the pointer family ahead of each mouse event", async () => {
+    const page = loadClick();
+    const { error } = await page.call("click", { selector: "#trigger" });
+    assert.equal(error, null);
+    assert.deepEqual(page.seen, [
+        "P:pointerover", "M:mouseover",
+        "P:pointerdown", "M:mousedown", "P:pointerup", "M:mouseup", "M:click",
+    ]);
+    assert.equal(page.focused(), 1);
+});
+
+test("a cancelled pointerdown suppresses the mouse press and the focus change", async () => {
+    const page = loadClick({ cancelsPointerDown: true });
+    await page.call("click", { selector: "#trigger" });
+    assert.deepEqual(page.seen, ["P:pointerover", "M:mouseover", "P:pointerdown", "P:pointerup", "M:click"]);
+    assert.equal(page.focused(), 0);
+    assert.equal(page.open(), true);
+});
+
+test("a cancelled mousedown keeps focus where it was, as the browser does", async () => {
+    const page = loadClick({ cancelsMouseDown: true });
+    await page.call("click", { selector: "#trigger", doubleClick: true });
+    assert.equal(page.focused(), 0);
+    assert.ok(page.seen.includes("M:mouseup") && page.seen.includes("M:dblclick"));
+});
+
+test("double click presses twice with pointer events and ends in dblclick", async () => {
+    const page = loadClick();
+    await page.call("click", { selector: "#trigger", doubleClick: true });
+    const press = ["P:pointerdown", "M:mousedown", "P:pointerup", "M:mouseup", "M:click"];
+    assert.deepEqual(page.seen, ["P:pointerover", "M:mouseover", ...press, ...press, "M:dblclick"]);
+});


### PR DESCRIPTION
## Problem

`click` on a Radix `DropdownMenu` trigger reports `Clicked <button>` but the menu never opens. Same for any control that toggles on `pointerdown`.

## Root cause

`simulateClick` dispatches `mouseover`, `mousedown`, `mouseup`, `click` and no pointer events. A real click on the same trigger delivers a trusted `pointerdown` that Radix cancels, after which the browser suppresses the compatibility mouse events. `hover` and `drag` already dispatch the pointer family; `click` was left mouse-only.

## Fix

Pointer events in real-input order, using the existing `pointerEvent` helper: `pointerover`, then per press `pointerdown`, `mousedown` and `focus()` only if `pointerdown` and `mousedown` were not cancelled, `pointerup`, `mouseup` if `pointerdown` was not cancelled, `click`. Double click repeats the press and ends in `dblclick`. Ordinary buttons see the same mouse events and focus as before with pointer events added ahead of each.

## Validation

- `node --test Tests/*.mjs`: 101/101 (4 new in `content-click-pointer.test.mjs`)
- With the change reverted, 3 of the new tests fail
- Live through the extension on a vite fixture with `@radix-ui/react-dropdown-menu` 2.1.15: tool click now opens the menu, a click on an item selects it, a second trigger click closes it; the trigger's event log matches a real OS click apart from `isTrusted`
