### PR TITLE
fix: drop_file entries resolve their files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug Fixes
 - `click` now dispatches `pointerdown`/`pointerup` ahead of `mousedown`/`mouseup`, and skips the mouse press and focus change when a handler cancels `pointerdown`, matching real input. Pointer-driven toggles such as Radix `DropdownMenu` triggers open instead of reporting a successful click that changed nothing.
+- `drop_file` now dispatches from the page's world and gives each dropped item a `webkitGetAsEntry()` whose `file()` resolves. Safari minted an entry for the in-memory File whose `file()` rejected with `NotFoundError`, so folder-aware drop zones that walk entries collected nothing and treated the drop as empty.
 
 ## [0.3.0] - 2026-08-28
 ### Added

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -808,6 +808,7 @@ async function injectContentScripts(tabId) {
                 "dialog-interceptor.js",
                 "console-interceptor.js",
                 "network-interceptor.js",
+                "file-drop.js",
             ],
             world: "MAIN",
         });

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -1355,11 +1355,37 @@
         return `Attached ${describeFiles(files)} to file input`;
     }
 
+    let dropQueue = Promise.resolve();
+
+    // Drops share one target marker, so they run one at a time.
     function dropFile(params) {
+        const run = dropQueue.then(() => dropFileNow(params));
+        dropQueue = run.catch(() => {});
+        return run;
+    }
+
+    async function dropFileNow(params) {
         const target = resolveElement({ uid: params.uid, selector: params.selector });
         const files = buildFiles(params);
-        const dataTransfer = transferFor(files);
+        const dropped = `Dropped ${describeFiles(files)} on <${target.tagName.toLowerCase()}>`;
 
+        // Page listeners only see item overrides made in their own world, so
+        // file-drop.js dispatches; without it the entry API stays broken.
+        const marker = `mcp-drop-${Date.now()}-${++bridgeRequestCounter}`;
+        target.setAttribute("data-mcp-drop-target", marker);
+        try {
+            await requestMainWorld("drop_files", { marker, files });
+            return dropped;
+        } catch (err) {
+            if (!String(err.message || err).endsWith("interceptor did not respond")) throw err;
+            dispatchDrop(target, transferFor(files));
+            return `${dropped} (page bridge unavailable; entry API not patched)`;
+        } finally {
+            target.removeAttribute("data-mcp-drop-target");
+        }
+    }
+
+    function dispatchDrop(target, dataTransfer) {
         target.scrollIntoView({ behavior: "instant", block: "center" });
         const rect = target.getBoundingClientRect();
         const baseOpts = {
@@ -1374,8 +1400,6 @@
         for (const type of ["dragenter", "dragover", "drop"]) {
             target.dispatchEvent(new DragEvent(type, baseOpts));
         }
-
-        return `Dropped ${describeFiles(files)} on <${target.tagName.toLowerCase()}>`;
     }
 
     // ─── Wait ────────────────────────────────────────────────────────

--- a/MCPSafari/MCPSafari Extension/Resources/file-drop.js
+++ b/MCPSafari/MCPSafari Extension/Resources/file-drop.js
@@ -1,0 +1,81 @@
+/**
+ * MCPSafari File Drop
+ *
+ * Dispatches drop_file drag events from the page's world. Page listeners see
+ * their own wrappers for a DataTransfer built in the content script's
+ * isolated world, so item fixes made there never reach them. Safari mints a
+ * FileSystemFileEntry for an in-memory File whose file() rejects with
+ * NotFoundError, so each item's webkitGetAsEntry is replaced with an entry
+ * that resolves the File from getAsFile().
+ *
+ * Injected at document_start before page scripts run.
+ */
+(() => {
+    if (window.__mcpFileDropLoaded) return;
+    window.__mcpFileDropLoaded = true;
+
+    function readableEntry(item) {
+        if (typeof item.webkitGetAsEntry !== "function") return null;
+        const entry = item.webkitGetAsEntry();
+        if (!entry || !entry.isFile) return entry;
+        const file = item.getAsFile();
+        return {
+            isFile: true,
+            isDirectory: false,
+            name: entry.name,
+            fullPath: entry.fullPath,
+            filesystem: entry.filesystem,
+            file(onSuccess) {
+                onSuccess(file);
+            },
+            getParent(onSuccess) {
+                onSuccess(entry.filesystem.root);
+            },
+        };
+    }
+
+    function dropFiles(params) {
+        const target = document.querySelector(`[data-mcp-drop-target="${params.marker}"]`);
+        if (!target) throw new Error("Drop target not found in page");
+
+        const dataTransfer = new DataTransfer();
+        for (const file of params.files) dataTransfer.items.add(file);
+        for (const item of dataTransfer.items) {
+            try {
+                const entry = readableEntry(item);
+                Object.defineProperty(item, "webkitGetAsEntry", { configurable: true, value: () => entry });
+            } catch {
+                // Leave the native entry in place; the drop still carries the files.
+            }
+        }
+
+        target.scrollIntoView({ behavior: "instant", block: "center" });
+        const rect = target.getBoundingClientRect();
+        const baseOpts = {
+            bubbles: true,
+            cancelable: true,
+            view: window,
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+            dataTransfer,
+        };
+        for (const type of ["dragenter", "dragover", "drop"]) {
+            target.dispatchEvent(new DragEvent(type, baseOpts));
+        }
+        return { dropped: params.files.length };
+    }
+
+    window.addEventListener("message", (event) => {
+        const message = event.data;
+        if (event.source !== window || message?.source !== "MCPSafariContent") return;
+        if (message.type !== "drop_files") return;
+
+        let reply;
+        try {
+            reply = { data: dropFiles(message.params || {}) };
+        } catch (error) {
+            reply = { error: error.message };
+        }
+        window.postMessage({ source: "MCPSafariPage", id: message.id, ...reply }, "*");
+    });
+})();

--- a/MCPSafari/MCPSafari Extension/Resources/manifest.json
+++ b/MCPSafari/MCPSafari Extension/Resources/manifest.json
@@ -20,7 +20,7 @@
     },
 
     "content_scripts": [{
-        "js": ["trace-interceptor.js", "dialog-interceptor.js", "console-interceptor.js", "network-interceptor.js"],
+        "js": ["trace-interceptor.js", "dialog-interceptor.js", "console-interceptor.js", "network-interceptor.js", "file-drop.js"],
         "matches": ["<all_urls>"],
         "run_at": "document_start",
         "all_frames": false,

--- a/Tests/content-file-attachment.test.mjs
+++ b/Tests/content-file-attachment.test.mjs
@@ -28,6 +28,9 @@ function makeElement(overrides = {}) {
     return {
         tagName: "DIV",
         events: [],
+        attributes: {},
+        setAttribute(name, value) { this.attributes[name] = value; },
+        removeAttribute(name) { delete this.attributes[name]; },
         scrollIntoView() {},
         getBoundingClientRect: () => ({ left: 10, top: 20, width: 100, height: 50 }),
         querySelector: () => null,
@@ -44,8 +47,18 @@ function makeFileInput(overrides = {}) {
 }
 
 // Loads content.js against a fake document whose querySelector returns `target`.
+// Bridge requests are collected; `call.reply(request, reply)` answers one the
+// way file-drop.js would, and `call.timeout()` fires the bridge timeout.
 function loadContent(target) {
     let runtimeListener;
+    let messageListener;
+    const timers = [];
+    const bridgeRequests = [];
+    const window = {
+        addEventListener: (_type, fn) => { messageListener = fn; },
+        removeEventListener() {},
+        postMessage: (message) => bridgeRequests.push(message),
+    };
 
     vm.runInNewContext(source, {
         browser: {
@@ -54,8 +67,8 @@ function loadContent(target) {
             },
         },
         document: { querySelector: () => target },
-        window: { addEventListener() {}, postMessage() {} },
-        setTimeout: () => 0,
+        window,
+        setTimeout: (fn) => timers.push(fn),
         clearTimeout() {},
         atob,
         Uint8Array,
@@ -65,10 +78,18 @@ function loadContent(target) {
         DragEvent: FakeEvent,
     });
 
-    return (action, params) => new Promise((resolve) => {
+    const call = (action, params) => new Promise((resolve) => {
         runtimeListener({ action, params }, {}, resolve);
     });
+    call.bridgeRequests = bridgeRequests;
+    call.reply = (request, reply) => {
+        messageListener({ source: window, data: { source: "MCPSafariPage", id: request.id, ...reply } });
+    };
+    call.timeout = () => timers.shift()();
+    return call;
 }
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 const PNG = { name: "shot.png", type: "image/png", data: Buffer.from([137, 80, 78, 71]).toString("base64") };
 const TXT = { name: "note.txt", type: "text/plain", data: Buffer.from("hi").toString("base64") };
@@ -120,13 +141,76 @@ test("upload_file rejects an empty file list", async () => {
     assert.equal(response.error, "No files provided");
 });
 
-test("drop_file dispatches dragenter, dragover, and drop carrying the files", async () => {
+test("drop_file hands the decoded files to the page world and unmarks the target", async () => {
     const zone = makeElement();
     const call = loadContent(zone);
 
-    const response = await call("drop_file", { selector: "#zone", files: [PNG] });
+    const pending = call("drop_file", { selector: "#zone", files: [PNG, TXT] });
+    await tick();
+
+    assert.equal(call.bridgeRequests.length, 1);
+    const request = call.bridgeRequests[0];
+    assert.equal(request.type, "drop_files");
+    assert.deepEqual(request.params.files.map((file) => file.name), ["shot.png", "note.txt"]);
+    assert.equal(request.params.files[0].size, 4);
+    assert.match(request.params.marker, /^mcp-drop-/);
+    assert.equal(zone.attributes["data-mcp-drop-target"], request.params.marker);
+
+    call.reply(request, { data: { dropped: 2 } });
+    const response = await pending;
 
     assert.equal(response.error, null);
+    assert.equal(response.data, "Dropped shot.png, note.txt on <div>");
+    assert.equal(zone.events.length, 0);
+    assert.deepEqual(zone.attributes, {});
+});
+
+test("drop_file runs one drop at a time so markers never overlap", async () => {
+    const zone = makeElement();
+    const call = loadContent(zone);
+
+    const first = call("drop_file", { selector: "#zone", files: [PNG] });
+    const second = call("drop_file", { selector: "#zone", files: [TXT] });
+    await tick();
+
+    assert.equal(call.bridgeRequests.length, 1);
+    call.reply(call.bridgeRequests[0], { data: { dropped: 1 } });
+    await first;
+    await tick();
+
+    assert.equal(call.bridgeRequests.length, 2);
+    assert.notEqual(call.bridgeRequests[1].params.marker, call.bridgeRequests[0].params.marker);
+    assert.equal(zone.attributes["data-mcp-drop-target"], call.bridgeRequests[1].params.marker);
+    call.reply(call.bridgeRequests[1], { data: { dropped: 1 } });
+    assert.equal((await second).data, "Dropped note.txt on <div>");
+    assert.deepEqual(zone.attributes, {});
+});
+
+test("drop_file reports a page-world error instead of dispatching blind", async () => {
+    const zone = makeElement();
+    const call = loadContent(zone);
+
+    const pending = call("drop_file", { selector: "#zone", files: [PNG] });
+    await tick();
+    call.reply(call.bridgeRequests[0], { error: "Drop target not found in page" });
+    const response = await pending;
+
+    assert.equal(response.error, "Drop target not found in page");
+    assert.equal(zone.events.length, 0);
+    assert.deepEqual(zone.attributes, {});
+});
+
+test("drop_file dispatches in its own world when the page bridge does not answer", async () => {
+    const zone = makeElement();
+    const call = loadContent(zone);
+
+    const pending = call("drop_file", { selector: "#zone", files: [PNG] });
+    await tick();
+    call.timeout();
+    const response = await pending;
+
+    assert.equal(response.error, null);
+    assert.match(response.data, /^Dropped shot.png on <div> \(page bridge unavailable/);
     assert.deepEqual(zone.events.map((event) => event.type), ["dragenter", "dragover", "drop"]);
     for (const event of zone.events) {
         assert.equal(event.cancelable, true);
@@ -134,4 +218,5 @@ test("drop_file dispatches dragenter, dragover, and drop carrying the files", as
         assert.equal(event.clientX, 60);
         assert.equal(event.clientY, 45);
     }
+    assert.deepEqual(zone.attributes, {});
 });

--- a/Tests/file-drop.test.mjs
+++ b/Tests/file-drop.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/file-drop.js", import.meta.url),
+    "utf8"
+);
+
+// Safari mints an entry for an in-memory File whose file() rejects, which is
+// the behavior the script papers over.
+function brokenEntry(file) {
+    return {
+        isFile: true,
+        isDirectory: false,
+        name: file.name,
+        fullPath: `/${file.name}`,
+        filesystem: { root: { isDirectory: true, fullPath: "/" } },
+        file(_onSuccess, onError) {
+            onError(new Error("NotFoundError: Path does not exist"));
+        },
+        getParent(_onSuccess, onError) {
+            onError(new Error("NotFoundError: Path does not exist"));
+        },
+    };
+}
+
+class FakeDataTransfer {
+    constructor(entryFor = brokenEntry) {
+        this.items = [];
+        this.items.add = (file) => {
+            this.items.push({
+                kind: "file",
+                getAsFile: () => file,
+                webkitGetAsEntry: () => entryFor(file),
+            });
+        };
+    }
+    get files() {
+        return this.items.map((item) => item.getAsFile());
+    }
+}
+
+class FakeEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        Object.assign(this, options);
+    }
+}
+
+function makeTarget() {
+    return {
+        events: [],
+        scrollIntoView() {},
+        getBoundingClientRect: () => ({ left: 10, top: 20, width: 100, height: 50 }),
+        dispatchEvent(event) {
+            this.events.push(event);
+            return true;
+        },
+    };
+}
+
+// Loads file-drop.js and returns a function that posts a bridge request and
+// resolves with the page's reply.
+function loadFileDrop({ target, DataTransfer = FakeDataTransfer } = {}) {
+    let onMessage;
+    const replies = [];
+    const window = {
+        addEventListener: (_type, fn) => { onMessage = fn; },
+        postMessage: (message) => replies.push(message),
+    };
+
+    vm.runInNewContext(source, {
+        window,
+        document: { querySelector: (selector) => (selector.includes("marker-1") ? target : null) },
+        DataTransfer,
+        DragEvent: FakeEvent,
+    });
+
+    return (params) => {
+        onMessage({ source: window, data: { source: "MCPSafariContent", id: "req", type: "drop_files", params } });
+        return replies.pop();
+    };
+}
+
+const PNG = new File([new Uint8Array([137, 80, 78, 71])], "shot.png", { type: "image/png" });
+const TXT = new File(["hi"], "note.txt", { type: "text/plain" });
+
+test("drop dispatches dragenter, dragover, drop with entries that resolve the files", async () => {
+    const target = makeTarget();
+    const request = loadFileDrop({ target });
+
+    const reply = request({ marker: "marker-1", files: [PNG, TXT] });
+
+    assert.equal(reply.source, "MCPSafariPage");
+    assert.equal(reply.id, "req");
+    assert.equal(reply.error, undefined);
+    assert.equal(reply.data.dropped, 2);
+    assert.deepEqual(target.events.map((event) => event.type), ["dragenter", "dragover", "drop"]);
+    const { dataTransfer } = target.events[2];
+    assert.equal(target.events[2].clientX, 60);
+    assert.equal(target.events[2].clientY, 45);
+    assert.deepEqual(dataTransfer.files.map((file) => file.name), ["shot.png", "note.txt"]);
+
+    for (const [index, item] of dataTransfer.items.entries()) {
+        const entry = item.webkitGetAsEntry();
+        assert.equal(entry.isFile, true);
+        assert.equal(entry.isDirectory, false);
+        assert.equal(entry.name, dataTransfer.files[index].name);
+        assert.equal(entry.fullPath, `/${entry.name}`);
+        const file = await new Promise((resolve, reject) => entry.file(resolve, reject));
+        assert.equal(file, dataTransfer.files[index]);
+        const parent = await new Promise((resolve, reject) => entry.getParent(resolve, reject));
+        assert.equal(parent, entry.filesystem.root);
+    }
+});
+
+test("drop still dispatches when the native entry API throws", () => {
+    const target = makeTarget();
+    class ThrowingDataTransfer extends FakeDataTransfer {
+        constructor() {
+            super(() => { throw new Error("entry unavailable"); });
+        }
+    }
+    const request = loadFileDrop({ target, DataTransfer: ThrowingDataTransfer });
+
+    const reply = request({ marker: "marker-1", files: [PNG] });
+
+    assert.equal(reply.data.dropped, 1);
+    assert.deepEqual(target.events.map((event) => event.type), ["dragenter", "dragover", "drop"]);
+    assert.throws(() => target.events[2].dataTransfer.items[0].webkitGetAsEntry(), /entry unavailable/);
+});
+
+test("drop leaves a null entry alone", () => {
+    const target = makeTarget();
+    class NullEntryDataTransfer extends FakeDataTransfer {
+        constructor() {
+            super(() => null);
+        }
+    }
+    const request = loadFileDrop({ target, DataTransfer: NullEntryDataTransfer });
+
+    request({ marker: "marker-1", files: [PNG] });
+
+    assert.equal(target.events[2].dataTransfer.items[0].webkitGetAsEntry(), null);
+});
+
+test("drop reports a missing target instead of dispatching", () => {
+    const target = makeTarget();
+    const request = loadFileDrop({ target });
+
+    const reply = request({ marker: "other", files: [PNG] });
+
+    assert.equal(reply.error, "Drop target not found in page");
+    assert.equal(target.events.length, 0);
+});


### PR DESCRIPTION
## Problem

`dataTransfer.files` is fine after `drop_file`, but `items[0].webkitGetAsEntry()` returns an entry whose `file()` call rejects with `NotFoundError: Path does not exist`. Drop zones with folder support walk entries first, so they end up with zero files and treat the drop as empty. A real drop of the same PNG on the same page works.

## Root cause

The `File` is built in memory from base64, so Safari's entry for it has no path behind it. The item cannot be patched from `content.js`: it runs in the isolated world, and the page has its own wrapper objects.

## Fix

A new main-world script, `file-drop.js`, builds the `DataTransfer`, gives each item an entry whose `file()` hands back the `File` from `getAsFile()`, and fires the drag events. The stand-in has the same surface as Safari's real entry, and its `getParent()` resolves the filesystem root like a real top-level entry. `content.js` tags the target with a data attribute, passes the decoded files over the existing `postMessage` bridge, and removes the tag when done. Drops run one at a time so tags never collide. If the bridge times out, the old in-world dispatch runs and the result says so.

## Validation

- `node --test Tests/*.mjs`: 104 pass, 8 new.
- Live in Safari 27.0 with a build of this branch: dropped two files onto a page that reads entries three ways (an `entry.file()` walker, `file-selector` 5.0.1, and `entry.name` before `getAsFile()`). All three got both files with the right sizes. On main @ f24ca11 the same page logs the `NotFoundError`.
