### PR TITLE
feat: screenshot crops to an element and scales the PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- `screenshot` accepts `uid` or `selector` to capture one element plus `padding` CSS px of context, and `scale` to shrink the PNG; the result says which viewport CSS px the image covers.
+
 ### Bug Fixes
 - Safari profiles no longer fight over the extension connection. Safari runs a separate instance of the extension in each profile, with its own background page and its own storage, and every instance reads the same token and dials the same port. The bridge held a single connection, so each instance evicted the one before it and the evicted instance reconnected, which left a two-profile setup connecting and disconnecting in a loop rather than working, including for the profile being driven. The bridge now holds one connection per profile, identified by the profile Safari reports to the app extension. Tool calls still drive one profile, the default when it is connected, and `status` lists every connected profile so the others are visible rather than silently dropped. Targeting a specific profile is not supported yet.
 

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -666,6 +666,14 @@ async function handleScreenshot(params) {
     // Context before the frame: a page that loses focus between the two reads
     // then produces a warning about a good frame rather than an all-clear on a
     // stale one.
+    // The target is scrolled into view before the context read so the
+    // reported viewport matches the frame.
+    const target = params.uid || params.selector
+        ? await sendToContentScript(tabId, {
+            action: "element_rect",
+            params: { uid: params.uid, selector: params.selector },
+        })
+        : null;
     const context = await capturePageContext(tabId);
     const dataUrl = await browser.tabs.captureVisibleTab(tab.windowId, {
         format: "png",
@@ -675,6 +683,7 @@ async function handleScreenshot(params) {
         // Raw base64, data URI prefix stripped
         image: dataUrl.replace(/^data:image\/\w+;base64,/, ""),
         ...context,
+        ...(target ? { target } : {}),
     };
 }
 

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -445,16 +445,22 @@ async function focusTabForNativeInput(tabIdParam) {
     return tabId;
 }
 
-// Native input works in screen coordinates. A subframe measures elements in its
-// own viewport and cannot reach a cross-origin parent's offset, so a subframe
-// target would produce a confidently wrong click. Refusing beats guessing.
-function requireTopFrameTarget(params) {
+// Native input works in screen coordinates, and captureVisibleTab captures the
+// top-level viewport. A subframe measures elements in its own viewport and
+// cannot reach a cross-origin parent's offset, so a subframe target would
+// produce a confidently wrong click or crop. Refusing beats guessing.
+const NATIVE_INPUT_TOP_FRAME_ONLY =
+    "Native input reaches the top frame only, and this element is inside an iframe. " +
+    "Omit native to use the synthetic path, which works in every frame.";
+
+const SCREENSHOT_TOP_FRAME_ONLY =
+    "Screenshot crops the top-level viewport, and this element is inside an iframe, " +
+    "so its position does not map onto the captured image. Capture without uid or selector.";
+
+function requireTopFrameTarget(params, reason = NATIVE_INPUT_TOP_FRAME_ONLY) {
     const frame = frameOfUid(params.uid) ?? frameOfUid(params.fromUid);
     if (frame) {
-        const error = new Error(
-            "Native input reaches the top frame only, and this element is inside an iframe. " +
-            "Omit native to use the synthetic path, which works in every frame."
-        );
+        const error = new Error(reason);
         error.code = "invalid_input";
         error.recoveryAction = "fix_input";
         throw error;
@@ -654,6 +660,7 @@ async function waitForTabLoad(tabId, beforeTab, timeoutMs = 15000, noNavigationT
 // ─── Screenshot Handler ─────────────────────────────────────────────
 
 async function handleScreenshot(params) {
+    requireTopFrameTarget(params, SCREENSHOT_TOP_FRAME_ONLY);
     const tabId = params.tabId || (await getActiveTabId());
     const tab = await browser.tabs.get(tabId);
 

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -157,6 +157,8 @@
                 return uploadFile(params);
             case "drop_file":
                 return dropFile(params);
+            case "element_rect":
+                return elementRect(params);
             case "wait":
                 return waitFor(params);
             case "start_trace":
@@ -1498,6 +1500,31 @@
         for (const type of ["dragenter", "dragover", "drop"]) {
             target.dispatchEvent(new DragEvent(type, baseOpts));
         }
+    }
+
+    // ─── Element rect (screenshot region) ────────────────────────────
+
+    // captureVisibleTab only sees the viewport, so the target is scrolled
+    // into view first. Scroll handlers (collapsing headers, virtualized
+    // lists) run at the next rendering opportunity, so the rect is measured
+    // after one frame; the timeout covers a hidden page, which never paints.
+    async function elementRect(params) {
+        const el = resolveElement({ uid: params.uid, selector: params.selector });
+        el.scrollIntoView({ behavior: "instant", block: "center", inline: "center" });
+        await new Promise((resolve) => {
+            const fallback = setTimeout(resolve, 100);
+            requestAnimationFrame(() => { clearTimeout(fallback); resolve(); });
+        });
+        const rect = el.getBoundingClientRect();
+        if (!(rect.width > 0) || !(rect.height > 0)) {
+            throw toolError(
+                "target_not_found",
+                `<${el.tagName.toLowerCase()}> has no rendered size, so there is nothing to capture`,
+                false,
+                "take_snapshot"
+            );
+        }
+        return { x: rect.left, y: rect.top, width: rect.width, height: rect.height };
     }
 
     // ─── Wait ────────────────────────────────────────────────────────

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -3,8 +3,10 @@ import ApplicationServices
 import Carbon
 import CoreGraphics
 import Foundation
+import ImageIO
 import Logging
 import MCP
+import UniformTypeIdentifiers
 
 struct RunStep: Equatable, Sendable {
     let tool: String
@@ -488,10 +490,13 @@ actor SafariMCPServer {
 
             Tool(
                 name: "screenshot",
-                description: "Capture visible tab as PNG. Pass filePath to save the PNG to disk and get the path back instead of inline image data.",
+                description: "Capture visible tab as PNG. Pass uid or selector to scroll that element into view and capture it with padding, scale to shrink the image, and filePath to save the PNG to disk and get the path back instead of inline image data.",
                 inputSchema: .object([
                     "type": .string("object"),
                     "properties": .object([
+                        "uid": Self.uid, "selector": Self.sel,
+                        "padding": .object(["type": .string("number"), "description": .string("CSS px kept around the element (default: 16)")]),
+                        "scale": .object(["type": .string("number"), "description": .string("Shrink the PNG by this factor, 0 to 1 (default: 1)")]),
                         "filePath": .object(["type": .string("string"), "description": .string("Save the PNG to this local path (~ expanded) and return the path instead of the image")]),
                         "tabId": Self.tab,
                     ]),
@@ -1495,6 +1500,17 @@ actor SafariMCPServer {
     private func handleScreenshot(_ args: [String: Value]) async throws -> CallTool.Result {
         var params: [String: AnyCodable] = [:]
         if let tabId = args["tabId"]?.intValue { params["tabId"] = AnyCodable(tabId) }
+        if let uid = args["uid"]?.stringValue { params["uid"] = AnyCodable(uid) }
+        if let selector = args["selector"]?.stringValue { params["selector"] = AnyCodable(selector) }
+        // Validate before the bridge call: a targeted capture scrolls the page.
+        let padding: Double
+        let scale: Double
+        do {
+            padding = try Self.capturePadding(args)
+            scale = try Self.captureScale(args)
+        } catch {
+            return Self.failureResult(toolFailure(for: error))
+        }
         let response = try await bridge.send(action: "screenshot", params: params)
 
         guard response.success, let raw = response.data?.stringValue else {
@@ -1504,14 +1520,29 @@ actor SafariMCPServer {
         // Current extensions send the image plus its capture context; older
         // ones send the base64 image on its own.
         let capture = Self.decodeCapture(raw)
-        let imageData = capture?["image"]?.stringValue ?? raw
+        var imageData = capture?["image"]?.stringValue ?? raw
 
         if let failure = Self.captureFailure(imageData) {
             return Self.failureResult(failure)
         }
-        let note = capture.flatMap(Self.captureNote)
+        var note = capture.flatMap(Self.captureNote)
+        var png = Data(base64Encoded: imageData) ?? Data()
 
-        if let filePath = args["filePath"], let png = Data(base64Encoded: imageData) {
+        do {
+            let clip = try Self.captureClip(args, capture: capture, padding: padding)
+            if clip != nil || scale < 1 {
+                let rendered = try Self.renderCapture(png, clip: clip, scale: scale)
+                png = rendered.png
+                imageData = png.base64EncodedString()
+                note = [note, Self.renderNote(rendered, args: args, capture: capture, scale: scale)]
+                    .compactMap { $0 }
+                    .joined(separator: " ")
+            }
+        } catch {
+            return Self.failureResult(toolFailure(for: error))
+        }
+
+        if let filePath = args["filePath"] {
             let url: URL
             do {
                 guard let path = filePath.stringValue else { throw FileAttachmentError("filePath must be a string") }
@@ -1557,6 +1588,124 @@ actor SafariMCPServer {
             throw FileAttachmentError("Cannot write screenshot to \(url.path) (\(error.localizedDescription))")
         }
         return url
+    }
+
+    struct RenderedCapture {
+        let png: Data
+        let width: Int
+        let height: Int
+        /// Device-pixel rect of the source frame that the PNG covers.
+        let clip: CGRect
+    }
+
+    static func capturePadding(_ args: [String: Value]) throws -> Double {
+        for key in ["uid", "selector"] where args[key] != nil && args[key]?.stringValue == nil {
+            throw ToolInputError("\(key) must be a string")
+        }
+        guard let value = args["padding"] else { return 16 }
+        guard let padding = numberValue(value), padding >= 0, padding.isFinite else {
+            throw ToolInputError("padding must be a number of CSS px, 0 or more")
+        }
+        return padding
+    }
+
+    /// Device-pixel rect around the requested element, or nil for the whole
+    /// frame. The extension measures the element in CSS px after scrolling
+    /// it into view; padding and devicePixelRatio are applied here.
+    static func captureClip(_ args: [String: Value], capture: [String: AnyCodable]?, padding: Double) throws -> CGRect? {
+        guard args["uid"]?.stringValue != nil || args["selector"]?.stringValue != nil else { return nil }
+        guard let target = capture?["target"]?.objectValue,
+              let x = number(target["x"]), let y = number(target["y"]),
+              let width = number(target["width"]), let height = number(target["height"]) else {
+            throw ToolInputError(
+                "This MCPSafari extension does not report element bounds for screenshot; update the extension or drop uid/selector"
+            )
+        }
+        let ratio = number(capture?["devicePixelRatio"]) ?? 1
+        return CGRect(x: x - padding, y: y - padding, width: width + 2 * padding, height: height + 2 * padding)
+            .applying(CGAffineTransform(scaleX: ratio, y: ratio))
+    }
+
+    static func captureScale(_ args: [String: Value]) throws -> Double {
+        guard let value = args["scale"] else { return 1 }
+        guard let scale = numberValue(value), scale > 0, scale <= 1 else {
+            throw ToolInputError("scale must be a number above 0 and at most 1")
+        }
+        return scale
+    }
+
+    /// Crops the frame to `clip` (device px, clamped to the frame) and scales
+    /// the result. Both happen on the server because the extension only has
+    /// captureVisibleTab, which returns the whole viewport at device scale.
+    static func renderCapture(_ png: Data, clip: CGRect?, scale: Double) throws -> RenderedCapture {
+        guard let source = CGImageSourceCreateWithData(png as CFData, nil),
+              var image = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+            throw FileAttachmentError("Safari returned a PNG that cannot be decoded")
+        }
+        let frame = CGRect(x: 0, y: 0, width: image.width, height: image.height)
+        var region = frame
+        if let clip {
+            region = clip.integral.intersection(frame)
+            guard !region.isNull, region.width >= 1, region.height >= 1 else {
+                throw ToolInputError("The element lies outside the captured viewport; scroll it into view or capture without uid/selector")
+            }
+            guard let cropped = image.cropping(to: region) else {
+                throw FileAttachmentError("Cannot crop the capture to \(region)")
+            }
+            image = cropped
+        }
+        if scale < 1 {
+            let width = max(1, Int((Double(image.width) * scale).rounded()))
+            let height = max(1, Int((Double(image.height) * scale).rounded()))
+            guard let context = CGContext(
+                data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                throw FileAttachmentError("Cannot allocate a \(width)x\(height) bitmap")
+            }
+            context.interpolationQuality = .high
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            guard let scaled = context.makeImage() else {
+                throw FileAttachmentError("Cannot scale the capture to \(width)x\(height)")
+            }
+            image = scaled
+        }
+        let output = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(output, UTType.png.identifier as CFString, 1, nil) else {
+            throw FileAttachmentError("Cannot encode the capture as PNG")
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw FileAttachmentError("Cannot encode the capture as PNG")
+        }
+        return RenderedCapture(png: output as Data, width: image.width, height: image.height, clip: region)
+    }
+
+    /// Tells the caller which part of the viewport the PNG covers, since the
+    /// frame note above no longer holds. With the viewport size from that
+    /// note, the PNG size is enough to map image px back to CSS px.
+    static func renderNote(
+        _ rendered: RenderedCapture, args: [String: Value], capture: [String: AnyCodable]?, scale: Double
+    ) -> String {
+        let ratio = number(capture?["devicePixelRatio"]) ?? 1
+        var parts: [String] = []
+        let target = args["uid"]?.stringValue.map { "uid \($0)" }
+            ?? args["selector"]?.stringValue.map { "selector \($0)" }
+        if let target {
+            let clip = rendered.clip
+            let css = clip.applying(CGAffineTransform(scaleX: 1 / ratio, y: 1 / ratio))
+            let at = { (value: CGFloat) in String(Int(value.rounded())) }
+            parts.append(
+                "Cropped to \(target): the PNG covers viewport CSS px "
+                + "(\(at(css.minX)), \(at(css.minY))) to (\(at(css.maxX)), \(at(css.maxY))), "
+                + "\(Int(clip.width))x\(Int(clip.height)) device px."
+            )
+        }
+        if scale < 1 {
+            parts.append("Scaled by \(scale) from device px: the PNG is \(rendered.width)x\(rendered.height) px.")
+        }
+        return parts.joined(separator: " ")
     }
 
     /// Safari resolves a failed capture to an empty or non-image payload, and

--- a/MCPServer/Tests/MCPSafariTests/ScreenshotRegionTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/ScreenshotRegionTests.swift
@@ -1,0 +1,180 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+import MCP
+import Testing
+import UniformTypeIdentifiers
+@testable import MCPSafari
+
+/// A 200x100 frame: red, with a blue bottom-right quadrant (image rows 50-99,
+/// columns 100-199), so a crop's origin is checkable on both axes from one
+/// pixel read.
+private func twoToneFrame() throws -> Data {
+    let context = try #require(CGContext(
+        data: nil, width: 200, height: 100, bitsPerComponent: 8, bytesPerRow: 0,
+        space: CGColorSpaceCreateDeviceRGB(), bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ))
+    context.setFillColor(CGColor(red: 1, green: 0, blue: 0, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: 200, height: 100))
+    // CGContext's origin is bottom-left, so this is the visual bottom-right.
+    context.setFillColor(CGColor(red: 0, green: 0, blue: 1, alpha: 1))
+    context.fill(CGRect(x: 100, y: 0, width: 100, height: 50))
+    let image = try #require(context.makeImage())
+    let output = NSMutableData()
+    let destination = try #require(CGImageDestinationCreateWithData(output, UTType.png.identifier as CFString, 1, nil))
+    CGImageDestinationAddImage(destination, image, nil)
+    #expect(CGImageDestinationFinalize(destination))
+    return output as Data
+}
+
+private struct Decoded {
+    let width: Int
+    let height: Int
+    let pixels: [UInt8]
+
+    init(_ png: Data) throws {
+        let source = try #require(CGImageSourceCreateWithData(png as CFData, nil))
+        let image = try #require(CGImageSourceCreateImageAtIndex(source, 0, nil))
+        width = image.width
+        height = image.height
+        var buffer = [UInt8](repeating: 0, count: width * height * 4)
+        let context = try #require(CGContext(
+            data: &buffer, width: width, height: height, bitsPerComponent: 8, bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(), bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        pixels = buffer
+    }
+
+    /// "red" or "blue" at an image-space pixel, top-left origin. A bitmap
+    /// context stores its top row first.
+    func tone(x: Int, y: Int) -> String {
+        let offset = (y * width + x) * 4
+        return pixels[offset] > pixels[offset + 2] ? "red" : "blue"
+    }
+}
+
+struct ScreenshotRegionTests {
+    @Test func cropUsesTopLeftImageCoordinates() throws {
+        let bottomRight = try SafariMCPServer.renderCapture(
+            twoToneFrame(), clip: CGRect(x: 150, y: 60, width: 40, height: 30), scale: 1
+        )
+        let decoded = try Decoded(bottomRight.png)
+        #expect((decoded.width, decoded.height) == (40, 30))
+        #expect(decoded.tone(x: 0, y: 0) == "blue")
+        #expect(decoded.tone(x: 39, y: 29) == "blue")
+        #expect(bottomRight.clip == CGRect(x: 150, y: 60, width: 40, height: 30))
+
+        let topRight = try SafariMCPServer.renderCapture(
+            twoToneFrame(), clip: CGRect(x: 150, y: 10, width: 40, height: 30), scale: 1
+        )
+        let topDecoded = try Decoded(topRight.png)
+        #expect(topDecoded.tone(x: 0, y: 0) == "red")
+        #expect(topDecoded.tone(x: 39, y: 29) == "red")
+    }
+
+    @Test func cropClampsToTheFrame() throws {
+        let rendered = try SafariMCPServer.renderCapture(
+            twoToneFrame(), clip: CGRect(x: -30, y: -10, width: 100, height: 200), scale: 1
+        )
+        #expect(rendered.clip == CGRect(x: 0, y: 0, width: 70, height: 100))
+        let decoded = try Decoded(rendered.png)
+        #expect(decoded.tone(x: 69, y: 50) == "red")
+    }
+
+    @Test func cropOutsideTheFrameIsAnInputError() throws {
+        #expect(throws: (any Error).self) {
+            try SafariMCPServer.renderCapture(
+                twoToneFrame(), clip: CGRect(x: 500, y: 0, width: 10, height: 10), scale: 1
+            )
+        }
+    }
+
+    @Test func scaleShrinksTheWholeFrame() throws {
+        let frame = try twoToneFrame()
+        let rendered = try SafariMCPServer.renderCapture(frame, clip: nil, scale: 0.5)
+        let decoded = try Decoded(rendered.png)
+        #expect((decoded.width, decoded.height) == (100, 50))
+        #expect(decoded.tone(x: 10, y: 40) == "red")
+        #expect(decoded.tone(x: 90, y: 10) == "red")
+        #expect(decoded.tone(x: 90, y: 40) == "blue")
+        #expect(rendered.png.count < frame.count)
+    }
+
+    @Test func cropThenScaleComposes() throws {
+        let rendered = try SafariMCPServer.renderCapture(
+            twoToneFrame(), clip: CGRect(x: 100, y: 50, width: 100, height: 50), scale: 0.25
+        )
+        let decoded = try Decoded(rendered.png)
+        #expect((decoded.width, decoded.height) == (25, 13))
+        #expect(decoded.tone(x: 12, y: 6) == "blue")
+    }
+
+    @Test func clipAppliesPaddingAndDevicePixelRatio() throws {
+        let capture: [String: AnyCodable] = [
+            "devicePixelRatio": AnyCodable(2),
+            "target": AnyCodable([
+                "x": AnyCodable(100), "y": AnyCodable(50),
+                "width": AnyCodable(40), "height": AnyCodable(20),
+            ]),
+        ]
+        let defaultPadding = try SafariMCPServer.captureClip(["uid": .string("e1")], capture: capture, padding: 16)
+        #expect(defaultPadding == CGRect(x: 168, y: 68, width: 144, height: 104))
+
+        let noPadding = try SafariMCPServer.captureClip(["selector": .string("#row")], capture: capture, padding: 0)
+        #expect(noPadding == CGRect(x: 200, y: 100, width: 80, height: 40))
+
+        let untargeted = try SafariMCPServer.captureClip([:], capture: capture, padding: 0)
+        #expect(untargeted == nil)
+    }
+
+    @Test func targetWithoutExtensionBoundsIsAnInputError() throws {
+        #expect(throws: (any Error).self) {
+            try SafariMCPServer.captureClip(["uid": .string("e1")], capture: ["devicePixelRatio": AnyCodable(2)], padding: 0)
+        }
+        #expect(throws: (any Error).self) {
+            try SafariMCPServer.captureClip(["uid": .string("e1")], capture: nil, padding: 0)
+        }
+    }
+
+    @Test func badPaddingAndScaleAreInputErrors() throws {
+        #expect(throws: (any Error).self) { try SafariMCPServer.capturePadding(["padding": .int(-1)]) }
+        #expect(throws: (any Error).self) { try SafariMCPServer.capturePadding(["padding": .string("8")]) }
+        #expect(throws: (any Error).self) { try SafariMCPServer.capturePadding(["uid": .int(7)]) }
+        let defaultPadding = try SafariMCPServer.capturePadding([:])
+        #expect(defaultPadding == 16)
+        #expect(throws: (any Error).self) { try SafariMCPServer.captureScale(["scale": .int(0)]) }
+        #expect(throws: (any Error).self) { try SafariMCPServer.captureScale(["scale": .double(1.5)]) }
+        #expect(throws: (any Error).self) { try SafariMCPServer.captureScale(["scale": .string("half")]) }
+        let unset = try SafariMCPServer.captureScale([:])
+        #expect(unset == 1)
+        let half = try SafariMCPServer.captureScale(["scale": .double(0.5)])
+        #expect(half == 0.5)
+    }
+
+    @Test func renderNoteMapsThePngBackToCssPixels() throws {
+        let rendered = SafariMCPServer.RenderedCapture(
+            png: Data(), width: 72, height: 52, clip: CGRect(x: 168, y: 68, width: 144, height: 104)
+        )
+        let note = SafariMCPServer.renderNote(
+            rendered, args: ["selector": .string("#row")], capture: ["devicePixelRatio": AnyCodable(2)], scale: 0.5
+        )
+        #expect(note == """
+        Cropped to selector #row: the PNG covers viewport CSS px (84, 34) to (156, 86), 144x104 device px. \
+        Scaled by 0.5 from device px: the PNG is 72x52 px.
+        """)
+
+        // Fractional CSS origins round rather than truncate: device x 1 at 1.5x is CSS 0.67.
+        let fractional = SafariMCPServer.renderNote(
+            SafariMCPServer.RenderedCapture(png: Data(), width: 3, height: 3, clip: CGRect(x: 1, y: 1, width: 3, height: 3)),
+            args: ["uid": .string("e1"), "selector": .string("#ignored")],
+            capture: ["devicePixelRatio": AnyCodable(1.5)], scale: 1
+        )
+        #expect(fractional == "Cropped to uid e1: the PNG covers viewport CSS px (1, 1) to (3, 3), 3x3 device px.")
+
+        // A scale that shrinks the frame to one pixel must not trap in formatting.
+        let tiny = try SafariMCPServer.renderCapture(twoToneFrame(), clip: nil, scale: 1e-20)
+        #expect((tiny.width, tiny.height) == (1, 1))
+        #expect(SafariMCPServer.renderNote(tiny, args: [:], capture: nil, scale: 1e-20).hasPrefix("Scaled by 1e-20"))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ The doctor checks the server executable, app and extension bundles, PlugInKit re
 
 | Tool | Description |
 |------|-------------|
-| `screenshot` | Capture the visible tab area as a PNG image, with viewport, scale, page visibility, and window focus; `filePath` saves it to disk and returns the path instead of inline image data |
+| `screenshot` | Capture the visible tab area as a PNG image, with viewport, scale, page visibility, and window focus; `uid`/`selector` crop to one element plus `padding` CSS px, `scale` shrinks the PNG, and `filePath` saves it to disk and returns the path instead of inline image data |
 
 ### JavaScript
 

--- a/Tests/background-frame-routing.test.mjs
+++ b/Tests/background-frame-routing.test.mjs
@@ -29,7 +29,10 @@ function loadBackground({ frames = [TOP, EMBED], respond }) {
         },
         tabs: {
             query: async () => [{ id: 1, active: true, windowId: 1 }],
-            get: async () => ({ id: 1, url: TOP.url, title: "Top", windowId: 1 }),
+            // active matters: a handler that reactivates the tab awaits delay(300),
+            // which the setTimeout shim below deliberately never resolves, so a
+            // regression would hang here instead of failing.
+            get: async () => ({ id: 1, active: true, url: TOP.url, title: "Top", windowId: 1 }),
             update: async () => {},
             sendMessage: async (tabId, message, options) => {
                 const frameId = options ? options.frameId : 0;
@@ -195,4 +198,19 @@ test("native input refuses a subframe target instead of clicking the wrong point
 
     // A top-frame uid is still allowed through.
     await call('handleNativePointer({ tabId: 1, uid: "f0e7" })');
+});
+
+test("a targeted screenshot refuses a subframe target instead of cropping the wrong region", async () => {
+    // captureVisibleTab returns the top-level viewport, and a subframe measures
+    // its element against its own. Cropping on that would silently produce a
+    // picture of somewhere else, and the element_rect request would go to the
+    // top frame, which does not know the uid.
+    const { call, sent } = loadBackground({ respond: () => ok(null) });
+
+    await assert.rejects(
+        () => call('handleScreenshot({ tabId: 1, uid: "f3e2" })'),
+        /top frame only|iframe/i
+    );
+
+    assert.equal(sent.length, 0, "it should refuse before scrolling the page");
 });

--- a/Tests/screenshot-region.test.mjs
+++ b/Tests/screenshot-region.test.mjs
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const background = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/background.js", import.meta.url),
+    "utf8"
+);
+const content = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+// Background harness: records what reaches the content script and in what
+// order relative to the frame capture.
+function loadBackground({ contentReply }) {
+    const log = [];
+    const browser = {
+        alarms: { create() {}, onAlarm: { addListener() {} } },
+        runtime: {
+            getManifest: () => ({ version: "9.9.9" }),
+            onMessage: { addListener() {} },
+            sendNativeMessage: async () => ({ tokens: {} }),
+        },
+        scripting: {
+            executeScript: async () => {
+                log.push("context");
+                return [{ result: { visible: true, hasFocus: true } }];
+            },
+        },
+        storage: {
+            local: { get: async () => ({}), set() {} },
+            session: { get: async () => ({}), set() {}, remove: async () => {} },
+        },
+        tabs: {
+            get: async (id) => ({ id, active: true, windowId: 1 }),
+            captureVisibleTab: async () => {
+                log.push("capture");
+                return "data:image/png;base64,AAAB";
+            },
+            sendMessage: async (_tabId, message) => {
+                log.push(`content:${message.action}`);
+                return contentReply(message);
+            },
+            onUpdated: { addListener() {}, removeListener() {} },
+            update: async () => {},
+        },
+    };
+    const context = vm.createContext({
+        browser,
+        clearTimeout() {},
+        console: { error() {}, log() {}, warn() {} },
+        Date,
+        Promise,
+        setTimeout: () => {},
+        WebSocket: class { send() {} },
+    });
+    vm.runInContext(background, context);
+    return { evaluate: (expression) => vm.runInContext(expression, context), log };
+}
+
+test("screenshot with uid asks the content script for the element rect before the frame", async () => {
+    const { evaluate, log } = loadBackground({
+        contentReply: (message) => {
+            assert.deepEqual({ ...message.params }, { uid: "e7", selector: undefined });
+            return { data: { x: 10, y: 20, width: 30, height: 40 }, error: null };
+        },
+    });
+
+    const capture = await evaluate('handleScreenshot({ tabId: 1, uid: "e7" })');
+
+    assert.deepEqual(log, ["content:element_rect", "context", "capture"]);
+    assert.equal(capture.image, "AAAB");
+    assert.equal(capture.target.x, 10);
+    assert.equal(capture.target.height, 40);
+});
+
+test("screenshot without a target never touches the content script", async () => {
+    const { evaluate, log } = loadBackground({
+        contentReply: () => { throw new Error("must not be called"); },
+    });
+
+    const capture = await evaluate("handleScreenshot({ tabId: 1 })");
+
+    assert.deepEqual(log, ["context", "capture"]);
+    assert.equal("target" in capture, false);
+});
+
+test("a content-script rect error fails the screenshot with its code", async () => {
+    const { evaluate, log } = loadBackground({
+        contentReply: () => ({
+            data: null,
+            error: "No element found for uid: e9",
+            errorCode: "stale_uid",
+            retryable: false,
+            recoveryAction: "take_snapshot",
+        }),
+    });
+
+    await assert.rejects(evaluate('handleScreenshot({ tabId: 1, uid: "e9" })'), (err) => {
+        assert.equal(err.code, "stale_uid");
+        return true;
+    });
+    assert.deepEqual(log, ["content:element_rect"]);
+});
+
+// Content harness: one element, resolvable by selector, with a controllable rect.
+// `settled`, when given, is the rect a scroll handler produces after the
+// scroll; the frame callback stands in for that handler having run.
+function loadContent(rect, settled, { paints = true } = {}) {
+    let listener;
+    const scrolls = [];
+    let current = rect;
+    const element = {
+        nodeType: 1,
+        tagName: "DIV",
+        getAttribute: () => null,
+        getBoundingClientRect: () => current,
+        scrollIntoView: (options) => scrolls.push(options),
+    };
+    vm.runInNewContext(content, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document: {
+            body: element,
+            querySelector: (selector) => (selector === "#row" ? element : null),
+            querySelectorAll: () => [],
+        },
+        Node: { ELEMENT_NODE: 1, TEXT_NODE: 3 },
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        requestAnimationFrame: (callback) => {
+            if (!paints) return 0;
+            return setTimeout(() => {
+                if (settled) current = settled;
+                callback();
+            }, 0);
+        },
+        window: { addEventListener() {}, removeEventListener() {}, postMessage() {} },
+    });
+    const call = (action, params) => new Promise((r) => listener({ action, params }, {}, r));
+    call.scrolls = scrolls;
+    return call;
+}
+
+test("element_rect scrolls the target into view and returns its rect", async () => {
+    const call = loadContent({ left: 12.5, top: 300, width: 200, height: 40 });
+
+    const { data, error } = await call("element_rect", { selector: "#row" });
+
+    assert.equal(error, null);
+    // Plain-object copies: the VM realm's objects carry a different prototype.
+    assert.deepEqual({ ...data }, { x: 12.5, y: 300, width: 200, height: 40 });
+    assert.deepEqual(call.scrolls.map((s) => ({ ...s })), [{ behavior: "instant", block: "center", inline: "center" }]);
+});
+
+test("element_rect measures after the frame in which scroll handlers run", async () => {
+    const call = loadContent({ left: 0, top: 300, width: 200, height: 40 }, { left: 0, top: 240, width: 200, height: 40 });
+
+    const { data } = await call("element_rect", { selector: "#row" });
+
+    // A collapsing header moved the target 60px up after the scroll.
+    assert.equal(data.y, 240);
+});
+
+test("element_rect still returns when the page never paints", async () => {
+    // A hidden page runs no animation frames; only the timeout fallback fires.
+    const call = loadContent({ left: 0, top: 0, width: 5, height: 5 }, null, { paints: false });
+    const started = Date.now();
+    const { data } = await call("element_rect", { selector: "#row" });
+    assert.equal(data.width, 5);
+    assert.ok(Date.now() - started < 1000);
+});
+
+test("element_rect refuses an element with no rendered size", async () => {
+    const call = loadContent({ left: 0, top: 0, width: 0, height: 0 });
+
+    const { data, error, errorCode } = await call("element_rect", { selector: "#row" });
+
+    assert.equal(data, null);
+    assert.match(error, /no rendered size/);
+    assert.equal(errorCode, "target_not_found");
+});
+
+test("element_rect reports a missing target", async () => {
+    const call = loadContent({ left: 0, top: 0, width: 5, height: 5 });
+
+    const { errorCode } = await call("element_rect", { selector: "#missing" });
+
+    assert.equal(errorCode, "target_not_found");
+});


### PR DESCRIPTION
## Problem

`screenshot` captures the whole viewport only. On a 1681x1010 @2x window that is a 3362x2020 PNG, 1.3 MB and about 1.7 M base64 chars inline, when the check is "does this row show its error text" or a coarse "does the page look right".

## Fix

Three optional parameters on `screenshot`, composing with `filePath`:

- `uid` or `selector`: the extension scrolls the element into view, waits one animation frame so scroll handlers settle, and returns its rect; the server crops the capture to it. Zero-size elements return `target_not_found`.
- `padding` (CSS px, default 16, clamped to the viewport): context around the element, since a field's error text is usually a sibling.
- `scale` (0 to 1): shrinks the PNG for coarse checks.

The crop is server-side because `captureVisibleTab` only returns the viewport; CSS px convert to device px with the reported `devicePixelRatio`, rounded. The result appends `Cropped to selector #row: the PNG covers viewport CSS px (24, 471) to (376, 543), 704x144 device px.` Invalid `padding`/`scale` are rejected before the bridge call so a bad argument does not scroll the page. An extension without `element_rect` returns `invalid_input` naming the extension.

## Validation

- `swift test`: 61/61 (9 new in `ScreenshotRegionTests`)
- `node --test Tests/*.mjs`: 119/119 (8 new in `screenshot-region.test.mjs`)
- `swift build -c release`; `tools/list` shows `uid`, `selector`, `padding`, `scale`
- Debug `xcodebuild` of the extension as in CI
- Live through the extension, fixture with a row under the fold, a hidden div, and a fixed element (1681x1010 @2x): full 3362x2020 / 1,312,569 B; `scale: 0.5` 1681x1010 / 243,495 B; `selector: #row` 704x144 / 17,077 B, same bytes via `uid`; `padding: 0` 640x80; `padding: 60` 840x320; hidden div, `#nope`, `padding: -1`, `scale: 2` return the expected errors
