### PR TITLE
feat: element tools reach into open shadow roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- `snapshot`, `find`, `click`, `type_text`, `form_input`, and `wait` now reach into open shadow roots, so a page built on web components no longer returns results that look complete and are not. `snapshot` follows the flattened tree, so content passed into a `<slot>` is reported once, where the slot places it. Closed shadow roots cannot be read by any API, so a custom element that occupies space while reporting no content of its own is marked `shadowClosed` instead of being reported as empty.
 
 ## [0.3.0] - 2026-09-08
 ### Added

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -200,6 +200,78 @@
         return document.body ? document.body.innerText : "";
     }
 
+    // ─── Shadow DOM Traversal ────────────────────────────────────────
+
+    // querySelector and TreeWalker each see a single tree, so anything inside
+    // a shadow root is invisible to them and a page built on web components
+    // returns results that look complete and are not. Every lookup below
+    // repeats itself against each open root instead. Closed roots stay
+    // unreachable: the page chose that, and no API reaches in.
+    function* allRoots(root = document) {
+        yield root;
+        for (const element of root.querySelectorAll("*")) {
+            if (element.shadowRoot) yield* allRoots(element.shadowRoot);
+        }
+    }
+
+    function deepQueryFirst(selector) {
+        for (const root of allRoots()) {
+            const found = root.querySelector(selector);
+            if (found) return found;
+        }
+        return null;
+    }
+
+    function deepQueryAll(selector, limit = Infinity) {
+        const found = [];
+        for (const root of allRoots()) {
+            for (const element of root.querySelectorAll(selector)) {
+                found.push(element);
+                if (found.length >= limit) return found;
+            }
+        }
+        return found;
+    }
+
+    // A walker rooted at the document would offer <html> and <body> themselves
+    // as matches, which the leaf-ish filters downstream exist to exclude. A
+    // shadow root has no such wrapper, so it is walked as-is.
+    function walkRootFor(root) {
+        return root === document ? document.body : root;
+    }
+
+    // A shadow host renders its shadow root, and the host's own children only
+    // appear where a <slot> puts them, so walking both would report slotted
+    // content twice. This follows the flattened tree the user actually sees.
+    function renderedChildren(element) {
+        if (element.shadowRoot) return Array.from(element.shadowRoot.children);
+        if (typeof element.assignedElements === "function") {
+            // flatten resolves nested slots and falls back to the slot's own
+            // children when nothing is assigned.
+            return element.assignedElements({ flatten: true });
+        }
+        return Array.from(element.children);
+    }
+
+    // Text belongs to whichever tree renders it, so a shadow host reports its
+    // shadow content instead of light children a slot placed somewhere else.
+    function renderedTextRoot(element) {
+        return element.shadowRoot || element;
+    }
+
+    // `shadowRoot` is null both for "no shadow root" and for a closed one, so a
+    // closed root can only be inferred: a custom element that occupies space
+    // while reporting no content of its own is rendering something we cannot
+    // see. Marking it beats reporting an empty element that looks absent.
+    function hasClosedShadowRoot(element) {
+        if (element.shadowRoot) return false;
+        if (!element.tagName || !element.tagName.includes("-")) return false;
+        if (element.children.length > 0) return false;
+        if (element.textContent && element.textContent.trim()) return false;
+        const rect = element.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+    }
+
     // ─── Accessibility Snapshot ──────────────────────────────────────
 
     const MAX_TREE_DEPTH = 30;
@@ -256,18 +328,19 @@
         // Children
         const children = [];
         let droppedChildren = false;
-        for (const child of element.children) {
+        for (const child of renderedChildren(element)) {
             const childNode = buildTree(child, depth + 1, budget);
             if (childNode) children.push(childNode);
             else if (budget.remaining <= 0) droppedChildren = true;
         }
         if (droppedChildren) node.childrenTruncated = true;
+        if (children.length === 0 && hasClosedShadowRoot(element)) node.shadowClosed = true;
 
         // Leaf nodes report their whole text content. Nodes that also have
         // element children report their own direct text nodes, so mixed
         // content such as <button><span>9</span>All</button> keeps "All".
         const rawText = children.length === 0
-            ? element.textContent
+            ? renderedTextRoot(element).textContent
             : ownTextContent(element);
         if (rawText) {
             const text = rawText.trim();
@@ -286,7 +359,7 @@
     // Text of an element's direct text-node children only, in document order.
     function ownTextContent(element) {
         let text = "";
-        for (const child of element.childNodes) {
+        for (const child of renderedTextRoot(element).childNodes) {
             if (child.nodeType === Node.TEXT_NODE) text += child.textContent;
         }
         return text;
@@ -418,7 +491,10 @@
             if (labelText) return labelText;
         }
         if (element.id) {
-            const label = document.querySelector(`label[for="${escapeCssString(element.id)}"]`);
+            // `for` resolves within the element's own tree, so a control inside
+            // a shadow root is labelled from that root and not from the document.
+            const scope = element.getRootNode ? element.getRootNode() : document;
+            const label = scope.querySelector(`label[for="${escapeCssString(element.id)}"]`);
             if (label) return label.textContent.trim();
         }
 
@@ -453,9 +529,7 @@
         const results = [];
 
         if (params.selector) {
-            const elements = document.querySelectorAll(params.selector);
-            for (const el of elements) {
-                if (results.length >= MAX_FIND_RESULTS) break;
+            for (const el of deepQueryAll(params.selector, MAX_FIND_RESULTS)) {
                 results.push(describeElement(el));
             }
         }
@@ -467,31 +541,35 @@
             const matches = (node) =>
                 node.textContent?.toLowerCase().includes(needle) ||
                 getAccessibleName(node)?.toLowerCase().includes(needle);
-            const walker = document.createTreeWalker(
-                document.body,
-                NodeFilter.SHOW_ELEMENT,
-                {
-                    acceptNode: (node) =>
-                        matches(node) && isVisible(node)
-                            ? NodeFilter.FILTER_ACCEPT
-                            : NodeFilter.FILTER_SKIP,
-                }
-            );
-            let node;
-            while ((node = walker.nextNode()) && results.length < MAX_FIND_RESULTS) {
-                // Only include leaf-ish elements (avoid returning <body> etc.)
-                if (
-                    node.children.length === 0 ||
-                    node.textContent.trim().length < 200
-                ) {
-                    results.push(describeElement(node));
+            for (const root of allRoots()) {
+                if (results.length >= MAX_FIND_RESULTS) break;
+                const walkRoot = walkRootFor(root);
+                if (!walkRoot) continue;
+                const walker = document.createTreeWalker(
+                    walkRoot,
+                    NodeFilter.SHOW_ELEMENT,
+                    {
+                        acceptNode: (node) =>
+                            matches(node) && isVisible(node)
+                                ? NodeFilter.FILTER_ACCEPT
+                                : NodeFilter.FILTER_SKIP,
+                    }
+                );
+                let node;
+                while ((node = walker.nextNode()) && results.length < MAX_FIND_RESULTS) {
+                    // Only include leaf-ish elements (avoid returning <body> etc.)
+                    if (
+                        node.children.length === 0 ||
+                        node.textContent.trim().length < 200
+                    ) {
+                        results.push(describeElement(node));
+                    }
                 }
             }
         }
 
         if (params.role) {
-            const allElements = document.querySelectorAll("*");
-            for (const el of allElements) {
+            for (const el of deepQueryAll("*")) {
                 if (results.length >= MAX_FIND_RESULTS) break;
                 if (getRole(el) === params.role && isVisible(el)) {
                     results.push(describeElement(el));
@@ -550,7 +628,7 @@
 
         // By CSS selector
         if (params.selector) {
-            const el = document.querySelector(params.selector);
+            const el = deepQueryFirst(params.selector);
             if (!el)
                 throw toolError(
                     "target_not_found",
@@ -565,23 +643,28 @@
         if (params.text) {
             const searchText = params.text.toLowerCase();
             const candidates = [];
-            const walker = document.createTreeWalker(
-                document.body,
-                NodeFilter.SHOW_ELEMENT,
-                {
-                    acceptNode: (node) =>
-                        node.textContent &&
-                        node.textContent.trim().toLowerCase().includes(searchText) &&
-                        isVisible(node) &&
-                        (node.children.length === 0 ||
-                            node.textContent.trim().length < 500)
-                            ? NodeFilter.FILTER_ACCEPT
-                            : NodeFilter.FILTER_SKIP,
+            for (const root of allRoots()) {
+                if (candidates.length >= 30) break;
+                const walkRoot = walkRootFor(root);
+                if (!walkRoot) continue;
+                const walker = document.createTreeWalker(
+                    walkRoot,
+                    NodeFilter.SHOW_ELEMENT,
+                    {
+                        acceptNode: (node) =>
+                            node.textContent &&
+                            node.textContent.trim().toLowerCase().includes(searchText) &&
+                            isVisible(node) &&
+                            (node.children.length === 0 ||
+                                node.textContent.trim().length < 500)
+                                ? NodeFilter.FILTER_ACCEPT
+                                : NodeFilter.FILTER_SKIP,
+                    }
+                );
+                let node;
+                while ((node = walker.nextNode()) && candidates.length < 30) {
+                    candidates.push(node);
                 }
-            );
-            let node;
-            while ((node = walker.nextNode()) && candidates.length < 30) {
-                candidates.push(node);
             }
             if (candidates.length === 0)
                 throw toolError(
@@ -882,7 +965,7 @@
         const missing = [];
 
         for (const [selector, value] of entries) {
-            const el = document.querySelector(selector);
+            const el = deepQueryFirst(selector);
             if (!el) {
                 missing.push(selector);
                 results.push(`${selector}: not found`);
@@ -1415,7 +1498,7 @@
 
         if (params.selector) {
             while (Date.now() - start < timeout) {
-                if (document.querySelector(params.selector)) {
+                if (deepQueryFirst(params.selector)) {
                     return `Element found: ${params.selector}`;
                 }
                 await new Promise((r) => setTimeout(r, 200));

--- a/README.md
+++ b/README.md
@@ -339,6 +339,12 @@ Tools that interact with elements accept multiple targeting strategies:
 | **Text** | `text: "Sign In"` | Interactive elements are ranked higher |
 | **Coordinates** | `x: 100, y: 200` | Last resort — click at exact position |
 
+### Shadow DOM
+
+Every targeting strategy reaches into open shadow roots, so pages built on web components (Lit, Stencil, Salesforce Lightning, most design-system elements) are readable and clickable. `snapshot` follows the flattened tree the user actually sees, so content passed into a `<slot>` is reported once, where the slot places it.
+
+Closed shadow roots are unreadable by any API. Rather than reporting such an element as empty, `snapshot` marks it `"shadowClosed": true` so a missing control is distinguishable from one the tools cannot see.
+
 ### Form Filling
 
 Use `form_input` to fill multiple fields at once:

--- a/Tests/ExtensionToolErrorTests.mjs
+++ b/Tests/ExtensionToolErrorTests.mjs
@@ -18,6 +18,8 @@ function contentHarness(document = {
     createTreeWalker: () => ({ nextNode: () => null }),
     elementFromPoint: () => null,
     querySelector: () => null,
+    // Shadow-root discovery asks every root for its elements.
+    querySelectorAll: () => [],
 }) {
     let listener;
     const context = vm.createContext({

--- a/Tests/content-element-text.test.mjs
+++ b/Tests/content-element-text.test.mjs
@@ -47,6 +47,19 @@ function loadContent(body) {
         documentElement: body,
         getElementById: () => null,
         querySelector: () => null,
+        // Shadow-root discovery asks each root for its elements so it can spot
+        // hosts. These fixtures are light DOM only, so every descendant counts.
+        querySelectorAll: () => {
+            const all = [];
+            const collect = (node) => {
+                for (const child of node.children) {
+                    all.push(child);
+                    collect(child);
+                }
+            };
+            collect(body);
+            return all;
+        },
         createTreeWalker(root, _whatToShow, filter) {
             const queue = [];
             const collect = (node) => {

--- a/Tests/content-shadow-dom.test.mjs
+++ b/Tests/content-shadow-dom.test.mjs
@@ -1,0 +1,282 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/content.js", import.meta.url),
+    "utf8"
+);
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+function textNode(value) {
+    return { nodeType: TEXT_NODE, textContent: value };
+}
+
+// Enough of a selector engine for the fixtures below: tag, #id, and .class.
+function matchesSelector(node, selector) {
+    if (selector === "*") return true;
+    if (selector.startsWith("#")) return node.id === selector.slice(1);
+    if (selector.startsWith(".")) {
+        return String(node.attributes.class || "").split(/\s+/).includes(selector.slice(1));
+    }
+    return node.tagName.toLowerCase() === selector.toLowerCase();
+}
+
+function descendants(root) {
+    const found = [];
+    const collect = (node) => {
+        for (const child of node.children) {
+            found.push(child);
+            collect(child);
+        }
+    };
+    collect(root);
+    return found;
+}
+
+// querySelectorAll stops at the shadow boundary in a real browser, and so does
+// this: descendants() never crosses into a host's shadowRoot. That boundary is
+// the whole point of the fixtures.
+function addQueries(node) {
+    node.querySelectorAll = (selector) =>
+        descendants(node).filter((el) => matchesSelector(el, selector));
+    node.querySelector = (selector) => node.querySelectorAll(selector)[0] || null;
+    return node;
+}
+
+function el(tag, options = {}, children = []) {
+    const node = {
+        nodeType: ELEMENT_NODE,
+        tagName: tag.toUpperCase(),
+        hidden: false,
+        id: options.id || "",
+        attributes: options.attributes || {},
+        childNodes: children,
+        shadowRoot: null,
+        clicked: 0,
+        getAttribute(name) {
+            return Object.prototype.hasOwnProperty.call(this.attributes, name)
+                ? this.attributes[name]
+                : null;
+        },
+        getBoundingClientRect: () => options.rect || { x: 0, y: 0, left: 0, top: 0, width: 10, height: 10 },
+        scrollIntoView() {},
+        focus() {},
+        dispatchEvent() {
+            node.clicked += 1;
+            return true;
+        },
+    };
+    Object.defineProperty(node, "children", {
+        get: () => node.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    Object.defineProperty(node, "textContent", {
+        get: () => node.childNodes.map((c) => c.textContent ?? "").join(""),
+    });
+    node.getRootNode = () => node.ownerRoot || documentRef;
+    if (options.slot) {
+        node.assignedElements = ({ flatten } = {}) =>
+            options.assigned && options.assigned.length
+                ? options.assigned
+                : (flatten ? node.children : []);
+    }
+    return addQueries(node);
+}
+
+// An open shadow root: a container that answers queries about its own tree.
+function shadowRoot(children) {
+    const root = { nodeType: 11, childNodes: children };
+    Object.defineProperty(root, "children", {
+        get: () => root.childNodes.filter((c) => c.nodeType === ELEMENT_NODE),
+    });
+    Object.defineProperty(root, "textContent", {
+        get: () => root.childNodes.map((c) => c.textContent ?? "").join(""),
+    });
+    return addQueries(root);
+}
+
+function attachShadow(host, children) {
+    host.shadowRoot = shadowRoot(children);
+    for (const child of children) markRoot(child, host.shadowRoot);
+    return host;
+}
+
+function markRoot(node, root) {
+    node.ownerRoot = root;
+    for (const child of node.children) markRoot(child, root);
+}
+
+let documentRef;
+
+// The click path constructs real event objects; only the type and the options
+// matter to these fixtures.
+class FakeEvent {
+    constructor(type, options = {}) {
+        this.type = type;
+        Object.assign(this, options);
+    }
+}
+
+function loadContent(body) {
+    let listener;
+    const document = {
+        body,
+        documentElement: body,
+        activeElement: null,
+        elementFromPoint: () => null,
+        getElementById: () => null,
+        createTreeWalker(root, _show, filter) {
+            const queue = descendants(root);
+            return {
+                nextNode() {
+                    while (queue.length) {
+                        const node = queue.shift();
+                        if (filter.acceptNode(node) === 1) return node;
+                    }
+                    return null;
+                },
+            };
+        },
+    };
+    addQueries({ ...document, children: body.children });
+    // Queries on the document run against the light tree rooted at body.
+    document.querySelectorAll = (selector) =>
+        descendants(body)
+            .concat(matchesSelector(body, selector) ? [body] : [])
+            .filter((element) => matchesSelector(element, selector));
+    document.querySelector = (selector) => document.querySelectorAll(selector)[0] || null;
+    documentRef = document;
+
+    vm.runInNewContext(source, {
+        browser: { runtime: { onMessage: { addListener: (fn) => { listener = fn; } } } },
+        document,
+        Node: { ELEMENT_NODE, TEXT_NODE },
+        NodeFilter: { SHOW_ELEMENT: 1, FILTER_ACCEPT: 1, FILTER_SKIP: 3 },
+        Event: FakeEvent,
+        MouseEvent: FakeEvent,
+        PointerEvent: FakeEvent,
+        KeyboardEvent: FakeEvent,
+        WeakRef,
+        setTimeout,
+        clearTimeout,
+        window: {
+            addEventListener: () => {},
+            removeEventListener: () => {},
+            postMessage: () => {},
+            innerHeight: 800,
+            getComputedStyle: () => ({ display: "block", visibility: "visible", opacity: "1" }),
+        },
+    });
+
+    return (action, params) => new Promise((r) => listener({ action, params }, {}, r));
+}
+
+// <my-card> hides a button behind an open shadow root, which is exactly what a
+// Lit or Stencil component looks like from the outside.
+function cardFixture() {
+    const shadowButton = el("button", { id: "inner" }, [textNode("Submit order")]);
+    const host = attachShadow(el("my-card"), [shadowButton]);
+    const body = el("body", {}, [el("h1", {}, [textNode("Checkout")]), host]);
+    return { body, shadowButton, host };
+}
+
+function flatten(node, out = []) {
+    if (!node) return out;
+    out.push(node);
+    for (const child of node.children || []) flatten(child, out);
+    return out;
+}
+
+test("snapshot descends an open shadow root", async () => {
+    const { body, shadowButton } = cardFixture();
+    const call = loadContent(body);
+
+    const { data: tree } = await call("snapshot", {});
+    const nodes = flatten(tree);
+
+    const button = nodes.find((n) => n.tag === "button");
+    assert.ok(button, "the shadow button is missing from the snapshot");
+    assert.equal(button.text, "Submit order");
+    assert.equal(shadowButton.clicked, 0);
+});
+
+test("find reaches a shadow element by selector, text, and role", async () => {
+    const { body } = cardFixture();
+    const call = loadContent(body);
+
+    const { data: bySelector } = await call("find", { selector: "button" });
+    assert.equal(bySelector.length, 1);
+    assert.equal(bySelector[0].tag, "button");
+
+    const { data: byText } = await call("find", { text: "Submit order" });
+    assert.ok(byText.some((r) => r.tag === "button"), "text search missed the shadow button");
+
+    const { data: byRole } = await call("find", { role: "button" });
+    assert.ok(byRole.some((r) => r.tag === "button"), "role search missed the shadow button");
+});
+
+test("a uid minted inside a shadow root still resolves for a click", async () => {
+    const { body, shadowButton } = cardFixture();
+    const call = loadContent(body);
+
+    const { data: tree } = await call("snapshot", {});
+    const button = flatten(tree).find((n) => n.tag === "button");
+
+    const response = await call("click", { uid: button.uid });
+
+    assert.equal(response.errorCode, undefined);
+    assert.ok(shadowButton.clicked > 0, "click never reached the shadow element");
+});
+
+test("click and form_input resolve a selector across the shadow boundary", async () => {
+    const { body, shadowButton } = cardFixture();
+    const call = loadContent(body);
+
+    const response = await call("click", { selector: "#inner" });
+
+    assert.equal(response.errorCode, undefined);
+    assert.ok(shadowButton.clicked > 0, "selector click never reached the shadow element");
+});
+
+test("slotted light content is reported once, not twice", async () => {
+    // The host slots its light child, so the flattened tree shows the label
+    // exactly where the slot puts it and nowhere else.
+    const lightLabel = el("span", { id: "label" }, [textNode("Buy now")]);
+    const slot = el("slot", { slot: true, assigned: [lightLabel] });
+    const host = attachShadow(el("my-button", {}, [lightLabel]), [slot]);
+    const body = el("body", {}, [host]);
+    const call = loadContent(body);
+
+    const { data: tree } = await call("snapshot", {});
+    const spans = flatten(tree).filter((n) => n.tag === "span");
+
+    assert.equal(spans.length, 1, "slotted content was reported twice");
+    assert.equal(spans[0].text, "Buy now");
+});
+
+test("a closed shadow root is marked instead of reading as an empty element", async () => {
+    // A custom element that occupies space while reporting no content of its
+    // own is rendering something behind a closed root.
+    const closed = el("x-secret", { rect: { x: 0, y: 0, left: 0, top: 0, width: 40, height: 20 } });
+    const body = el("body", {}, [closed]);
+    const call = loadContent(body);
+
+    const { data: tree } = await call("snapshot", {});
+    const node = flatten(tree).find((n) => n.tag === "x-secret");
+
+    assert.ok(node, "the host itself should still be reported");
+    assert.equal(node.shadowClosed, true);
+});
+
+test("an ordinary element with no shadow root is not marked closed", async () => {
+    const body = el("body", {}, [el("div", {}, [textNode("plain")]), el("span")]);
+    const call = loadContent(body);
+
+    const { data: tree } = await call("snapshot", {});
+    for (const node of flatten(tree)) {
+        assert.equal(node.shadowClosed, undefined, `${node.tag} was wrongly marked closed`);
+    }
+});


### PR DESCRIPTION
Every element walk in `content.js` used `querySelector` or a `TreeWalker` over a single tree, so anything inside a shadow root was invisible. `snapshot` omitted it, `find` never matched it, and `click` could not reach it by selector, which reads as "the element is not there" rather than "the tool cannot see it".

Adds `allRoots()`, yielding the document plus every open shadow root, and routes the selector, text, and role lookups through it. `buildTree` now walks the flattened tree, so a host reports its shadow content and slotted light children appear once, where the slot puts them. The `label[for=...]` lookup resolves within the element's own root.

Closed roots cannot be read by any API. A custom element that occupies space while reporting no content of its own is marked `shadowClosed`, so a control the tools cannot see is distinguishable from one that is absent.

Validation: `node --test Tests/*.mjs` is 118/118 with 7 new in `content-shadow-dom.test.mjs`. With `content.js` reverted, 5 of the 7 fail; the other two are regression guards against double-reporting slotted content and against false `shadowClosed` marks.

Resolves #57