### PR TITLE
feat: iframe content is readable and reachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Element UIDs are now frame-qualified: `e42` becomes `f0e42`, where the prefix names the frame that minted it. UIDs are read back from a `snapshot` rather than written by hand, so this only affects anything that stored one across the upgrade.
+
 ### Added
+- Iframe content is now readable and reachable. `snapshot` returns the tab as one tree, hanging each frame's document on the `<iframe>` that hosts it, and `find` searches every frame. No tool gained a frame argument: a UID routes to its own frame, and a selector or text target searches frames in order, top frame first. A frame whose host `<iframe>` cannot be matched by resolved `src` is attached to the parent tree and counted in `unmatchedFrames` instead of being dropped. Native input still reaches the top frame only, because a subframe cannot read a cross-origin parent's offset, and now fails with `invalid_input` instead of acting on the wrong point. `read_console` and `read_network` continue to report the top frame only.
 - `snapshot`, `find`, `click`, `type_text`, `form_input`, and `wait` now reach into open shadow roots, so a page built on web components no longer returns results that look complete and are not. `snapshot` follows the flattened tree, so content passed into a `<slot>` is reported once, where the slot places it. Closed shadow roots cannot be read by any API, so a custom element that occupies space while reporting no content of its own is marked `shadowClosed` instead of being reported as empty.
 
 ## [0.3.0] - 2026-09-08

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -287,10 +287,7 @@ async function handleRequest(request) {
             case "stop_trace":
             case "get_console_messages":
             case "get_network_requests":
-                data = await sendToContentScript(params.tabId, {
-                    action,
-                    params,
-                });
+                data = await dispatchToContent(action, params);
                 break;
 
             // Console (proxy to content script)
@@ -441,7 +438,24 @@ async function focusTabForNativeInput(tabIdParam) {
     return tabId;
 }
 
+// Native input works in screen coordinates. A subframe measures elements in its
+// own viewport and cannot reach a cross-origin parent's offset, so a subframe
+// target would produce a confidently wrong click. Refusing beats guessing.
+function requireTopFrameTarget(params) {
+    const frame = frameOfUid(params.uid) ?? frameOfUid(params.fromUid);
+    if (frame) {
+        const error = new Error(
+            "Native input reaches the top frame only, and this element is inside an iframe. " +
+            "Omit native to use the synthetic path, which works in every frame."
+        );
+        error.code = "invalid_input";
+        error.recoveryAction = "fix_input";
+        throw error;
+    }
+}
+
 async function handleNativeTypeText(params) {
+    requireTopFrameTarget(params);
     const tabId = await focusTabForNativeInput(params.tabId);
     await sendToContentScript(tabId, {
         action: "prepare_native_input",
@@ -451,6 +465,7 @@ async function handleNativeTypeText(params) {
 }
 
 async function handleNativePressKey(params) {
+    requireTopFrameTarget(params);
     const tabId = await focusTabForNativeInput(params.tabId);
     await sendToContentScript(tabId, {
         action: "prepare_native_key",
@@ -460,6 +475,7 @@ async function handleNativePressKey(params) {
 }
 
 async function handleNativePointer(params) {
+    requireTopFrameTarget(params);
     const tabId = await focusTabForNativeInput(params.tabId);
     return sendToContentScript(tabId, {
         action: "native_pointer_points",
@@ -767,11 +783,182 @@ async function handleResizeWindow(params) {
 
 // ─── Content Script Communication ────────────────────────────────────
 
-async function sendToContentScript(tabId, message) {
+// ─── Frame Routing ───────────────────────────────────────────────────
+
+// content.js runs in every frame, each with its own uid counter, so a uid
+// names the frame that minted it. That keeps frames out of the tool contract:
+// nothing takes a frameId, the uid carries it.
+const UID_PATTERN = /^f(\d+)e\d+$/;
+
+function frameOfUid(value) {
+    const match = UID_PATTERN.exec(String(value ?? ""));
+    return match ? Number(match[1]) : null;
+}
+
+async function listFrames(tabId) {
+    try {
+        const frames = await browser.webNavigation.getAllFrames({ tabId });
+        if (frames && frames.length > 0) return frames;
+    } catch (err) {
+        console.warn("[MCPSafari] Frame enumeration failed:", err);
+    }
+    return [{ frameId: 0, parentFrameId: -1, url: "" }];
+}
+
+// A frame whose document refuses the content script (a sandboxed or already
+// unloaded one) must not fail the whole call, so misses are dropped.
+async function collectFromFrames(tabId, message) {
+    const frames = await listFrames(tabId);
+    const collected = [];
+    for (const frame of frames) {
+        try {
+            collected.push({
+                frameId: frame.frameId,
+                data: await sendToContentScript(tabId, message, frame.frameId),
+            });
+        } catch (err) {
+            if (frame.frameId === 0) throw err;
+        }
+    }
+    return collected;
+}
+
+// Targeting by selector or text has no frame in it, so the frames are tried in
+// order and the first that resolves the target wins. The top frame is tried
+// first, which keeps single-frame pages behaving exactly as before.
+async function sendToFirstMatchingFrame(tabId, message) {
+    const frames = await listFrames(tabId);
+    let firstFailure;
+    for (const frame of frames) {
+        try {
+            return await sendToContentScript(tabId, message, frame.frameId);
+        } catch (err) {
+            if (!firstFailure) firstFailure = err;
+        }
+    }
+    throw firstFailure || new Error("No frame handled the request");
+}
+
+// Reads the whole tab as one tree by asking each frame for its own and hanging
+// each result on the <iframe> that hosts it, so an agent sees the page the way
+// a person does instead of a top frame with holes in it.
+async function snapshotAcrossFrames(tabId, params) {
+    const frames = await listFrames(tabId);
+    const trees = new Map();
+    for (const frame of frames) {
+        try {
+            const tree = await sendToContentScript(
+                tabId,
+                { action: "snapshot", params },
+                frame.frameId
+            );
+            if (tree) trees.set(frame.frameId, tree);
+        } catch (err) {
+            if (frame.frameId === 0) throw err;
+        }
+    }
+
+    const childFrames = new Map();
+    for (const frame of frames) {
+        if (frame.frameId === 0) continue;
+        const siblings = childFrames.get(frame.parentFrameId) || [];
+        siblings.push(frame);
+        childFrames.set(frame.parentFrameId, siblings);
+    }
+
+    const root = trees.get(0);
+    if (root) spliceFrames(root, 0, childFrames, trees);
+    return root;
+}
+
+function collectFrameHosts(node, hosts = []) {
+    if (!node || typeof node !== "object") return hosts;
+    if (typeof node.frameSrc === "string") hosts.push(node);
+    for (const child of node.children || []) collectFrameHosts(child, hosts);
+    return hosts;
+}
+
+// getAllFrames reports each frame's URL but not which element hosts it, so the
+// two are matched on the resolved src. Identical srcs are matched in document
+// order, and a frame whose host cannot be identified is attached to the parent
+// tree rather than dropped.
+function spliceFrames(tree, frameId, childFrames, trees) {
+    const children = childFrames.get(frameId) || [];
+    const hosts = collectFrameHosts(tree);
+    const claimed = new Set();
+    const orphans = [];
+
+    for (const frame of children) {
+        const subtree = trees.get(frame.frameId);
+        if (!subtree) continue;
+        spliceFrames(subtree, frame.frameId, childFrames, trees);
+
+        const host = hosts.find((h) => !claimed.has(h) && h.frameSrc === frame.url);
+        if (host) {
+            claimed.add(host);
+            host.children = [subtree];
+        } else {
+            orphans.push(subtree);
+        }
+    }
+
+    if (orphans.length > 0) {
+        tree.children = (tree.children || []).concat(orphans);
+        tree.unmatchedFrames = orphans.length;
+    }
+    for (const host of hosts) delete host.frameSrc;
+}
+
+// Routes one content action. Frames are an implementation detail here: a uid
+// says which frame owns the element, a search spans them all, and everything
+// else stays on the top frame where it always ran.
+async function dispatchToContent(action, params, message) {
+    const payload = message || { action, params };
+    const targetFrame = frameOfUid(params.uid) ?? frameOfUid(params.fromUid);
+    if (targetFrame !== null) {
+        return sendToContentScript(params.tabId, payload, targetFrame);
+    }
+
+    if (action === "snapshot") return snapshotAcrossFrames(params.tabId, params);
+    if (action === "read_page" && params.format === "snapshot") {
+        return snapshotAcrossFrames(params.tabId, params);
+    }
+
+    if (action === "find") {
+        const collected = await collectFromFrames(params.tabId, payload);
+        return collected.flatMap((entry) => entry.data || []);
+    }
+
+    if (FRAME_SEARCHING_ACTIONS.has(action) && (params.selector || params.text)) {
+        return sendToFirstMatchingFrame(params.tabId, payload);
+    }
+
+    return sendToContentScript(params.tabId, payload, 0);
+}
+
+// Acting on an element the caller named by selector or text: the element can
+// live in any frame, so the search has to cross them.
+const FRAME_SEARCHING_ACTIONS = new Set([
+    "click",
+    "type_text",
+    "form_input",
+    "select_option",
+    "hover",
+    "drag",
+    "upload_file",
+    "drop_file",
+    "scroll",
+    "wait",
+]);
+
+async function sendToContentScript(tabId, message, frameId = 0) {
     const resolvedTabId = tabId || (await getActiveTabId());
+    // The frame learns its own id from the request it is answering.
+    message = { ...message, frameId };
+    const options = { frameId };
 
     try {
-        const response = await browser.tabs.sendMessage(resolvedTabId, message);
+        const response = await browser.tabs.sendMessage(resolvedTabId, message, options);
         if (!response) throw new Error("Receiving end does not exist");
         if (response && response.error) {
             throw toolErrorFromResponse(response);
@@ -787,7 +974,8 @@ async function sendToContentScript(tabId, message) {
             await injectContentScripts(resolvedTabId);
             const response = await browser.tabs.sendMessage(
                 resolvedTabId,
-                message
+                message,
+                options
             );
             if (!response) throw new Error("Content script did not respond after injection");
             if (response && response.error) {
@@ -812,8 +1000,10 @@ async function injectContentScripts(tabId) {
             ],
             world: "MAIN",
         });
+        // content.js is declared for all frames, so a re-injection has to cover
+        // them too or the frames stay unreachable until the next navigation.
         await browser.scripting.executeScript({
-            target: { tabId },
+            target: { tabId, allFrames: true },
             files: ["content.js"],
         });
         await delay(100);

--- a/MCPSafari/MCPSafari Extension/Resources/content.js
+++ b/MCPSafari/MCPSafari Extension/Resources/content.js
@@ -16,6 +16,12 @@
     const reverseUidMap = new Map();
     let bridgeRequestCounter = 0;
 
+    // Every frame runs its own copy of this script with its own counter, so a
+    // bare "e1" is ambiguous across frames. The background knows which frame it
+    // is addressing and stamps each request, so the id arrives with the work
+    // rather than needing a handshake that a tool call could outrun.
+    let frameId = 0;
+
     function toolError(code, message, retryable, recoveryAction) {
         const error = new Error(message);
         error.code = code;
@@ -46,7 +52,7 @@
 
     function getUid(element) {
         if (uidMap.has(element)) return uidMap.get(element);
-        const uid = `e${++uidCounter}`;
+        const uid = `f${frameId}e${++uidCounter}`;
         uidMap.set(element, uid);
         reverseUidMap.set(uid, new WeakRef(element));
         if (uidFinalizer) uidFinalizer.register(element, uid);
@@ -97,6 +103,8 @@
     browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
         // Only handle messages meant for content scripts
         if (!message || !message.action) return false;
+
+        if (typeof message.frameId === "number") frameId = message.frameId;
 
         handleAction(message.action, message.params || {})
             .then((data) => sendResponse({ data, error: null }))
@@ -323,6 +331,13 @@
         // Href for links
         if (tag === "a" && element.href) {
             node.href = element.href;
+        }
+
+        // A frame's document belongs to a different content script, so the
+        // background splices it in here. It matches on the resolved src and
+        // drops this marker afterwards.
+        if (tag === "iframe" || tag === "frame") {
+            node.frameSrc = element.src || "";
         }
 
         // Children

--- a/MCPSafari/MCPSafari Extension/Resources/manifest.json
+++ b/MCPSafari/MCPSafari Extension/Resources/manifest.json
@@ -29,7 +29,7 @@
         "js": ["content.js"],
         "matches": ["<all_urls>"],
         "run_at": "document_start",
-        "all_frames": false
+        "all_frames": true
     }],
 
     "action": {

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Tools that interact with elements accept multiple targeting strategies:
 
 | Strategy | Example | When to Use |
 |----------|---------|-------------|
-| **UID** | `uid: "e42"` | Most precise — from a `snapshot` |
+| **UID** | `uid: "f0e42"` | Most precise — from a `snapshot` |
 | **CSS selector** | `selector: "#login-btn"` | When you know the DOM structure |
 | **Text** | `text: "Sign In"` | Interactive elements are ranked higher |
 | **Coordinates** | `x: 100, y: 200` | Last resort — click at exact position |
@@ -344,6 +344,14 @@ Tools that interact with elements accept multiple targeting strategies:
 Every targeting strategy reaches into open shadow roots, so pages built on web components (Lit, Stencil, Salesforce Lightning, most design-system elements) are readable and clickable. `snapshot` follows the flattened tree the user actually sees, so content passed into a `<slot>` is reported once, where the slot places it.
 
 Closed shadow roots are unreadable by any API. Rather than reporting such an element as empty, `snapshot` marks it `"shadowClosed": true` so a missing control is distinguishable from one the tools cannot see.
+
+### Iframes
+
+Iframe content is readable and clickable. `snapshot` returns the whole tab as one tree, hanging each frame's document on the `<iframe>` that hosts it, and `find` searches every frame.
+
+No tool takes a frame argument. A UID names the frame that minted it (`f3e12` is element 12 in frame 3), so targeting by UID routes automatically; targeting by selector or text searches frames in order, top frame first. Frames are matched to their host `<iframe>` by resolved `src`, and a frame whose host cannot be identified is attached to the parent tree and counted in `unmatchedFrames` rather than dropped.
+
+Two limits are worth knowing. Native input (`native: true`) reaches the top frame only, because a subframe measures elements in its own viewport and cannot read a cross-origin parent's offset; it fails with `invalid_input` rather than clicking the wrong point. `read_console` and `read_network` report the top frame only.
 
 ### Form Filling
 

--- a/Tests/background-frame-routing.test.mjs
+++ b/Tests/background-frame-routing.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+    new URL("../MCPSafari/MCPSafari Extension/Resources/background.js", import.meta.url),
+    "utf8"
+);
+
+const TOP = { frameId: 0, parentFrameId: -1, url: "https://top.example/" };
+const EMBED = { frameId: 3, parentFrameId: 0, url: "https://embed.example/form" };
+
+// Every message the router sends is recorded with the frame it was aimed at,
+// so the assertions can check routing and not just the returned value.
+function loadBackground({ frames = [TOP, EMBED], respond }) {
+    const sent = [];
+    const browser = {
+        alarms: { create() {}, onAlarm: { addListener() {} } },
+        runtime: {
+            getManifest: () => ({ version: "9.9.9" }),
+            onMessage: { addListener() {} },
+            sendNativeMessage: async () => ({ tokens: {} }),
+        },
+        scripting: { executeScript: async () => [] },
+        storage: {
+            local: { get: async () => ({}), set() {} },
+            session: { get: async () => ({}), set() {}, remove: async () => {} },
+        },
+        tabs: {
+            query: async () => [{ id: 1, active: true, windowId: 1 }],
+            get: async () => ({ id: 1, url: TOP.url, title: "Top", windowId: 1 }),
+            update: async () => {},
+            sendMessage: async (tabId, message, options) => {
+                const frameId = options ? options.frameId : 0;
+                sent.push({ tabId, frameId, action: message.action, params: message.params });
+                return respond(frameId, message);
+            },
+            onUpdated: { addListener() {}, removeListener() {} },
+        },
+        webNavigation: { getAllFrames: async () => frames },
+        windows: { update: async () => {} },
+    };
+
+    const context = vm.createContext({
+        browser,
+        clearTimeout,
+        console: { error() {}, log() {}, warn() {} },
+        Date,
+        Promise,
+        // The delay() after a re-injection has to resolve or the router hangs.
+        // The reconnect backoff must not, or the harness loops forever.
+        setTimeout: (fn, ms) => {
+            if ((ms || 0) <= 200) queueMicrotask(fn);
+            return 0;
+        },
+        WebSocket: class { send() {} },
+    });
+    vm.runInContext(source, context);
+
+    return {
+        sent,
+        call: (expression) => vm.runInContext(expression, context),
+    };
+}
+
+const ok = (data) => ({ data, error: null });
+
+function topTree() {
+    return {
+        uid: "f0e1",
+        tag: "body",
+        children: [
+            { uid: "f0e6", tag: "h1", text: "Checkout" },
+            { uid: "f0e7", tag: "iframe", frameSrc: EMBED.url },
+        ],
+    };
+}
+
+const embedTree = () => ({
+    uid: "f3e1",
+    tag: "body",
+    children: [{ uid: "f3e2", tag: "input", role: "textbox" }],
+});
+
+test("a uid routes to the frame that minted it", async () => {
+    const { call, sent } = loadBackground({ respond: () => ok("Clicked <input>") });
+
+    await call('dispatchToContent("click", { tabId: 1, uid: "f3e2" })');
+
+    assert.equal(sent.length, 1, "a uid should not need a search");
+    assert.equal(sent[0].frameId, 3);
+    assert.equal(sent[0].action, "click");
+});
+
+test("a top-frame uid still goes to frame 0", async () => {
+    const { call, sent } = loadBackground({ respond: () => ok("Clicked <button>") });
+
+    await call('dispatchToContent("click", { tabId: 1, uid: "f0e7" })');
+
+    assert.equal(sent[0].frameId, 0);
+});
+
+test("snapshot hangs each frame's tree on the iframe that hosts it", async () => {
+    const { call } = loadBackground({
+        respond: (frameId) => ok(frameId === 0 ? topTree() : embedTree()),
+    });
+
+    const tree = await call('dispatchToContent("snapshot", { tabId: 1 })');
+    const iframe = tree.children.find((c) => c.tag === "iframe");
+
+    assert.ok(iframe, "the iframe node should survive splicing");
+    assert.equal(iframe.children.length, 1);
+    assert.equal(iframe.children[0].children[0].uid, "f3e2");
+    // The marker exists to match frames, so it does not reach the caller.
+    assert.equal("frameSrc" in iframe, false);
+    assert.equal(tree.unmatchedFrames, undefined);
+});
+
+test("a frame whose host cannot be identified is attached, not dropped", async () => {
+    const orphan = { frameId: 4, parentFrameId: 0, url: "https://other.example/widget" };
+    const { call } = loadBackground({
+        frames: [TOP, orphan],
+        respond: (frameId) => ok(frameId === 0 ? topTree() : embedTree()),
+    });
+
+    const tree = await call('dispatchToContent("snapshot", { tabId: 1 })');
+
+    assert.equal(tree.unmatchedFrames, 1);
+    assert.ok(
+        tree.children.some((c) => c.children?.[0]?.uid === "f3e2"),
+        "the unmatched frame's content should still be reachable"
+    );
+});
+
+test("find fans out and returns matches from every frame", async () => {
+    const { call, sent } = loadBackground({
+        respond: (frameId) =>
+            ok(frameId === 0
+                ? [{ uid: "f0e6", tag: "h1" }]
+                : [{ uid: "f3e2", tag: "input" }]),
+    });
+
+    const results = await call('dispatchToContent("find", { tabId: 1, text: "a" })');
+
+    // Arrays built inside the vm carry that realm's prototype, so copy first.
+    assert.deepEqual([...results].map((r) => r.uid), ["f0e6", "f3e2"]);
+    assert.deepEqual(sent.map((s) => s.frameId), [0, 3]);
+});
+
+test("a selector target searches frames until one resolves it", async () => {
+    // The top frame does not have the element; the router must keep going.
+    const { call, sent } = loadBackground({
+        respond: (frameId) => {
+            if (frameId === 0) return { data: null, error: "No element found", errorCode: "target_not_found" };
+            return ok("Clicked <input>");
+        },
+    });
+
+    const result = await call('dispatchToContent("click", { tabId: 1, selector: "#card" })');
+
+    assert.equal(result, "Clicked <input>");
+    assert.deepEqual(sent.map((s) => s.frameId), [0, 3]);
+});
+
+test("a subframe that refuses the content script does not fail the whole read", async () => {
+    const { call } = loadBackground({
+        respond: (frameId) => {
+            if (frameId === 0) return ok([{ uid: "f0e6", tag: "h1" }]);
+            throw new Error("Could not establish connection");
+        },
+    });
+
+    const results = await call('dispatchToContent("find", { tabId: 1, text: "a" })');
+
+    assert.deepEqual([...results].map((r) => r.uid), ["f0e6"]);
+});
+
+test("the content script is told which frame it is answering for", async () => {
+    const { call, sent } = loadBackground({ respond: () => ok(null) });
+
+    await call('dispatchToContent("click", { tabId: 1, uid: "f3e2" })');
+
+    // The uid counter in that frame depends on this arriving with the request.
+    assert.equal(sent[0].frameId, 3);
+});
+
+test("native input refuses a subframe target instead of clicking the wrong point", async () => {
+    const { call } = loadBackground({ respond: () => ok(null) });
+
+    await assert.rejects(
+        () => call('handleNativePointer({ tabId: 1, uid: "f3e2" })'),
+        /top frame only/i
+    );
+
+    // A top-frame uid is still allowed through.
+    await call('handleNativePointer({ tabId: 1, uid: "f0e7" })');
+});

--- a/Tests/content-uid-lifecycle.test.mjs
+++ b/Tests/content-uid-lifecycle.test.mjs
@@ -108,7 +108,8 @@ test("every minted uid is registered for cleanup", async () => {
     // Registered against the element, so the token is dropped when it goes.
     assert.equal(registrations.length, 3, "body and both buttons");
     for (const node of [body, first, second]) {
-        assert.match(uidFor(registrations, node) ?? "", /^e\d+$/);
+        // Frame-qualified: the prefix names the frame that minted the uid.
+        assert.match(uidFor(registrations, node) ?? "", /^f\d+e\d+$/);
     }
 });
 


### PR DESCRIPTION
Both `content_scripts` entries set `all_frames: false`, so `content.js` only ever ran in the top document. Anything inside an iframe was absent from `snapshot` and unreachable by `find`, `click`, and `type_text`, which presents as a missing element rather than an out-of-scope one.

`content.js` now runs in every frame. Each frame learns its own id from the request it is answering, so UIDs are frame-qualified and no handshake can be outrun by a tool call. The background routes on that: a UID goes to its own frame, `snapshot` asks every frame and hangs each tree on the `<iframe>` that hosts it, `find` fans out, and a selector or text target searches frames in order. No tool gained a frame argument.

Frames are matched to their host by resolved `src`, which cannot be exact when two iframes share one. An unmatched frame is attached to the parent tree and counted in `unmatchedFrames` rather than dropped.

Native input stays on the top frame. A subframe measures elements in its own viewport and cannot read a cross-origin parent's offset, so a subframe target would produce a confidently wrong click; it now fails with `invalid_input` naming the synthetic path. The MAIN-world interceptors stay top-frame only, so console, network, and trace capture are unchanged.

UIDs change shape: `e42` becomes `f0e42`. They are read back from a snapshot rather than written by hand, so this only affects anything that stored one across the upgrade.

Validation: `node --test Tests/*.mjs` is 127/127 with 9 new in `background-frame-routing.test.mjs`. With `background.js` reverted, all 9 fail.

Resolves #58