### PR TITLE
fix: hold one bridge connection per Safari profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Bug Fixes
+- Safari profiles no longer fight over the extension connection. Safari runs a separate instance of the extension in each profile, with its own background page and its own storage, and every instance reads the same token and dials the same port. The bridge held a single connection, so each instance evicted the one before it and the evicted instance reconnected, which left a two-profile setup connecting and disconnecting in a loop rather than working, including for the profile being driven. The bridge now holds one connection per profile, identified by the profile Safari reports to the app extension. Tool calls still drive one profile, the default when it is connected, and `status` lists every connected profile so the others are visible rather than silently dropped. Targeting a specific profile is not supported yet.
 
 ## [0.3.0] - 2026-09-09
 ### Added

--- a/MCPSafari/MCPSafari Extension/Resources/background.js
+++ b/MCPSafari/MCPSafari Extension/Resources/background.js
@@ -13,6 +13,7 @@ const AUTO_SCAN_RANGE = 10; // Ports 8089-8098 are auto-managed
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 5000;
 const AUTO_CLEANUP_MS = 120_000;
+const DEFAULT_PROFILE_ID = "default";
 
 // ─── Multi-Connection State ──────────────────────────────────────────
 // All ports in the scan range (8089-8098) are initialized at startup.
@@ -26,6 +27,11 @@ const connections = new Map();
 const manualPorts = new Set();
 let selectedTabId = null;
 let legacyAuthToken = null;
+// Safari runs a separate instance of this extension per profile, each with its own
+// background page reading the same tokens. Without an identity in the handshake every
+// instance looks like the same client, and the server evicts whichever one connected
+// first. The appex reads it from SFExtensionProfileKey; "default" means Safari sent none.
+let profileId = DEFAULT_PROFILE_ID;
 const authTokensByPort = new Map();
 const staleTokensByPort = new Map();
 
@@ -97,6 +103,7 @@ function connectToPort(port) {
             auth: authToken,
             extensionVersion: EXTENSION_VERSION,
             protocolVersion: BRIDGE_PROTOCOL_VERSION,
+            profileId,
         }));
         console.log(`[MCPSafari:${port}] Sent auth token`);
     };
@@ -1154,6 +1161,9 @@ async function loadAuthTokens() {
             "com.epistates.MCPSafari.Extension",
             { type: "getTokens" }
         );
+        if (response && typeof response.profile === "string" && response.profile) {
+            profileId = response.profile;
+        }
         if (response && response.tokens) {
             authTokensByPort.clear();
             legacyAuthToken = null;

--- a/MCPSafari/MCPSafari Extension/SafariWebExtensionHandler.swift
+++ b/MCPSafari/MCPSafari Extension/SafariWebExtensionHandler.swift
@@ -45,6 +45,12 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
             } else {
                 responseBody = ["error": "No token files found in \(result.checkedPaths.joined(separator: ", "))"]
             }
+
+            // Safari runs a separate extension instance per profile, each with its own
+            // background page. The bridge needs to tell them apart so they stop evicting
+            // one another, and this handler is the only place the identity is available.
+            // Safari omits the key for the default profile.
+            responseBody["profile"] = profile?.uuidString ?? Self.defaultProfileID
         } else {
             responseBody = ["echo": message as Any]
         }
@@ -58,6 +64,10 @@ class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
 
         context.completeRequest(returningItems: [ response ], completionHandler: nil)
     }
+
+    /// Reported when Safari supplies no `SFExtensionProfileKey`, which is how the
+    /// default profile presents. Must match `WebSocketBridge.defaultProfileID`.
+    static let defaultProfileID = "default"
 
     private struct TokenLoadResult {
         let tokens: [String: String]

--- a/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
+++ b/MCPServer/Sources/mcp-safari/SafariMCPServer.swift
@@ -205,7 +205,7 @@ actor SafariMCPServer {
         [
             Tool(
                 name: "status",
-                description: "Report local Safari MCP listener, authentication, version, and token health. Works without an extension connection.",
+                description: "Report local Safari MCP listener, authentication, version, token health, and which Safari profiles are connected. Works without an extension connection.",
                 inputSchema: .object(["type": .string("object"), "properties": .object([:])]),
                 annotations: .init(readOnlyHint: true, openWorldHint: false)
             ),

--- a/MCPServer/Sources/mcp-safari/WebSocketBridge.swift
+++ b/MCPServer/Sources/mcp-safari/WebSocketBridge.swift
@@ -5,6 +5,20 @@ import Network
 struct ExtensionMetadata: Codable, Equatable {
     let version: String?
     let protocolVersion: Int?
+    /// Which Safari profile's extension instance authenticated. Safari omits the
+    /// profile key for the default profile, and extension builds predating profile
+    /// support send nothing at all, so both land on `WebSocketBridge.defaultProfileID`.
+    let profileID: String
+
+    init(
+        version: String?,
+        protocolVersion: Int?,
+        profileID: String = WebSocketBridge.defaultProfileID
+    ) {
+        self.version = version
+        self.protocolVersion = protocolVersion
+        self.profileID = profileID
+    }
 }
 
 enum HandshakeDecision: Equatable {
@@ -18,6 +32,18 @@ enum BridgeHandshake {
         let auth: String
         let extensionVersion: String?
         let protocolVersion: Int?
+        let profileId: String?
+    }
+
+    /// Blank or absent means the default profile, which is also what Safari sends
+    /// for it and what an extension build without profile support sends for every
+    /// profile. Trimmed because it is reflected back in log lines.
+    static func normalizedProfileID(_ raw: String?) -> String {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return WebSocketBridge.defaultProfileID }
+
+        return trimmed
     }
 
     static func decision(for data: Data, expectedToken: String) -> HandshakeDecision? {
@@ -32,7 +58,8 @@ enum BridgeHandshake {
         }
         return .accept(.init(
             version: message.extensionVersion,
-            protocolVersion: message.protocolVersion
+            protocolVersion: message.protocolVersion,
+            profileID: normalizedProfileID(message.profileId)
         ))
     }
 }
@@ -71,6 +98,16 @@ actor WebSocketBridge {
         case authenticated
     }
 
+    /// One connected Safari profile. Safari exposes no profile *name* to either the
+    /// extension or the app extension, so `id` is the opaque `SFExtensionProfileKey`
+    /// UUID (or `"default"`), and `index` is this server's stable short handle for it.
+    struct ProfileStatus: Codable, Equatable {
+        let id: String
+        let index: Int
+        let extensionVersion: String?
+        let extensionProtocolVersion: Int?
+    }
+
     struct Status: Codable, Equatable {
         let serverVersion: String
         let protocolVersion: Int
@@ -82,6 +119,7 @@ actor WebSocketBridge {
         let tokenFileSecure: Bool?
         let extensionVersion: String?
         let extensionProtocolVersion: Int?
+        let profiles: [ProfileStatus]
         let lastError: Failure?
 
         enum CodingKeys: String, CodingKey {
@@ -95,6 +133,7 @@ actor WebSocketBridge {
             case tokenFileSecure
             case extensionVersion
             case extensionProtocolVersion
+            case profiles
             case lastError
         }
 
@@ -122,6 +161,7 @@ actor WebSocketBridge {
             } else {
                 try container.encodeNil(forKey: .extensionProtocolVersion)
             }
+            try container.encode(profiles, forKey: .profiles)
             if let lastError {
                 try container.encode(lastError, forKey: .lastError)
             } else {
@@ -131,10 +171,25 @@ actor WebSocketBridge {
     }
 
     private var listener: NWListener?
-    /// The authenticated extension connection currently allowed to receive MCP requests.
-    private var connection: NWConnection?
-    /// A newly accepted connection that has not completed the token handshake yet.
-    private var authenticatingConnection: NWConnection?
+    /// One authenticated connection per Safari profile.
+    ///
+    /// Safari runs a separate, complete instance of the extension in every profile:
+    /// its own background page, its own storage, its own tab ID space. They all read
+    /// the same token and dial the same port. Holding a single connection here meant
+    /// each instance evicted the last one, whose reconnect then evicted it back, and a
+    /// two-profile setup flapped instead of working (#54).
+    private var connections: [String: NWConnection] = [:]
+    /// Reverse lookup so a connection's own callbacks can find their profile.
+    private var profileIDsByConnection: [ObjectIdentifier: String] = [:]
+    private var metadataByProfile: [String: ExtensionMetadata] = [:]
+    /// Profiles in the order they first authenticated. A profile keeps its index for
+    /// this server's lifetime, including across its own reconnects, so the short
+    /// handle in `status` does not shuffle under the caller.
+    private var profileOrder: [String] = []
+    /// Accepted connections that have not completed the token handshake, oldest first.
+    /// Kept as a list rather than a single slot for the same reason as `connections`:
+    /// a second profile dialing in must not cancel the first one mid-handshake.
+    private var authenticatingConnections: [NWConnection] = []
     private struct PendingRequest {
         let connectionID: ObjectIdentifier
         let continuation: CheckedContinuation<BridgeResponse, any Error>
@@ -152,6 +207,14 @@ actor WebSocketBridge {
 
     /// Authentication token that the extension must send as its first message.
     let authToken: String
+
+    /// Stands in for Safari's default profile, which sends no `SFExtensionProfileKey`.
+    /// Must match `SafariWebExtensionHandler.defaultProfileID`.
+    static let defaultProfileID = "default"
+
+    /// Cap on connections held mid-handshake. Generous for real profile counts, and
+    /// bounds what an unauthenticated local process can pin open.
+    private static let maxAuthenticatingConnections = 8
     /// Primary token root. The sandboxed extension reads tokens through a
     /// home-relative-path exception that the sandbox evaluates against the
     /// *resolved* path, and `~/.config` is commonly symlinked into a dotfiles
@@ -248,16 +311,40 @@ actor WebSocketBridge {
         }
     }
 
-    var isConnected: Bool { connection != nil }
+    var isConnected: Bool { !connections.isEmpty }
+
+    /// The profile that tool calls target when the caller names none.
+    ///
+    /// Safari gives an extension no way to ask which profile is frontmost, so this
+    /// prefers the default profile and otherwise takes the earliest to connect. The
+    /// point is that it is deterministic and that `status` lists the others, rather
+    /// than silently picking a different winner between calls.
+    private var activeProfileID: String? {
+        if connections[Self.defaultProfileID] != nil { return Self.defaultProfileID }
+        return profileOrder.first { connections[$0] != nil }
+    }
+
+    private func profileStatuses() -> [ProfileStatus] {
+        profileOrder.enumerated().compactMap { index, profileID in
+            guard connections[profileID] != nil else { return nil }
+            let metadata = metadataByProfile[profileID]
+            return ProfileStatus(
+                id: profileID,
+                index: index,
+                extensionVersion: metadata?.version,
+                extensionProtocolVersion: metadata?.protocolVersion
+            )
+        }
+    }
 
     func status() -> Status {
         let tokenFilePath = Self.tokenFilePath(for: port)
         let fileManager = FileManager.default
         let tokenFileExists = fileManager.fileExists(atPath: tokenFilePath)
         let permissions = (try? fileManager.attributesOfItem(atPath: tokenFilePath)[.posixPermissions] as? NSNumber)?.intValue
-        let connectionStatus: ConnectionStatus = connection != nil
+        let connectionStatus: ConnectionStatus = !connections.isEmpty
             ? .authenticated
-            : authenticatingConnection != nil ? .authenticating : .disconnected
+            : authenticatingConnections.isEmpty ? .disconnected : .authenticating
 
         return Status(
             serverVersion: MCPSafariProduct.version,
@@ -270,6 +357,7 @@ actor WebSocketBridge {
             tokenFileSecure: tokenFileExists ? permissions == 0o600 : nil,
             extensionVersion: extensionVersion,
             extensionProtocolVersion: extensionProtocolVersion,
+            profiles: profileStatuses(),
             lastError: lastError
         )
     }
@@ -402,10 +490,13 @@ actor WebSocketBridge {
     func stop() {
         listener?.cancel()
         listener = nil
-        authenticatingConnection?.cancel()
-        authenticatingConnection = nil
-        connection?.cancel()
-        connection = nil
+        for pending in authenticatingConnections { pending.cancel() }
+        authenticatingConnections.removeAll()
+        for connection in connections.values { connection.cancel() }
+        connections.removeAll()
+        profileIDsByConnection.removeAll()
+        metadataByProfile.removeAll()
+        profileOrder.removeAll()
         listenerStatus = .stopped
         extensionVersion = nil
         extensionProtocolVersion = nil
@@ -415,7 +506,7 @@ actor WebSocketBridge {
 
     /// Send a request to the extension and await the correlated response.
     func send(action: String, params: [String: AnyCodable] = [:], timeout: TimeInterval = 30) async throws -> BridgeResponse {
-        guard let connection else {
+        guard let profileID = activeProfileID, let connection = connections[profileID] else {
             throw BridgeError.notConnected
         }
         let connectionID = ObjectIdentifier(connection)
@@ -480,6 +571,21 @@ actor WebSocketBridge {
         pendingRequests.removeAll()
     }
 
+    /// Fails only the work that was in flight on one connection. One profile going
+    /// away must not fail another profile's requests, which is what a blanket drain
+    /// would do now that several are held at once.
+    private func drainPendingRequests(for conn: NWConnection, error: any Error) {
+        let connectionID = ObjectIdentifier(conn)
+        for (id, pending) in pendingRequests where pending.connectionID == connectionID {
+            pendingRequests.removeValue(forKey: id)
+            pending.continuation.resume(throwing: error)
+        }
+    }
+
+    private func removeAuthenticating(_ conn: NWConnection) {
+        authenticatingConnections.removeAll { $0 === conn }
+    }
+
     private func handleListenerState(_ state: NWListener.State, listener source: NWListener) {
         guard listener === source else { return }
         switch state {
@@ -497,12 +603,13 @@ actor WebSocketBridge {
         // Accept the socket, but don't make it active until the token handshake
         // succeeds. This prevents unauthenticated local clients from receiving
         // or spoofing MCP tool traffic.
-        if let existing = authenticatingConnection {
-            logger.info("Replacing pending unauthenticated extension connection")
-            existing.cancel()
+        if authenticatingConnections.count >= Self.maxAuthenticatingConnections {
+            let oldest = authenticatingConnections.removeFirst()
+            logger.warning("Too many connections awaiting authentication — dropping the oldest")
+            oldest.cancel()
         }
 
-        authenticatingConnection = newConnection
+        authenticatingConnections.append(newConnection)
         logger.info("Safari extension connected, awaiting authentication")
 
         newConnection.stateUpdateHandler = { [weak self] state in
@@ -523,28 +630,36 @@ actor WebSocketBridge {
             logger.info("Extension connection ready")
         case .failed(let error):
             logger.error("Extension connection failed: \(error)")
-            if connection === conn {
-                connection = nil
-                extensionVersion = nil
-                extensionProtocolVersion = nil
-                drainPendingRequests(error: BridgeError.notConnected)
-            }
-            if authenticatingConnection === conn {
-                authenticatingConnection = nil
-            }
+            forget(conn)
         case .cancelled:
             logger.info("Extension connection closed")
-            if connection === conn {
-                connection = nil
-                extensionVersion = nil
-                extensionProtocolVersion = nil
-                drainPendingRequests(error: BridgeError.notConnected)
-            }
-            if authenticatingConnection === conn {
-                authenticatingConnection = nil
-            }
+            forget(conn)
         default:
             break
+        }
+    }
+
+    /// Drops every trace of one connection. Safe to call for a connection that was
+    /// never authenticated, and for one already superseded by a reconnect from the
+    /// same profile: the identity check keeps a late `.cancelled` from the old socket
+    /// from evicting the new one.
+    private func forget(_ conn: NWConnection) {
+        removeAuthenticating(conn)
+
+        guard let profileID = profileIDsByConnection.removeValue(forKey: ObjectIdentifier(conn))
+        else { return }
+
+        if connections[profileID] === conn {
+            connections.removeValue(forKey: profileID)
+            metadataByProfile.removeValue(forKey: profileID)
+            logger.info("Safari extension disconnected (profile \(profileID))")
+        }
+
+        drainPendingRequests(for: conn, error: BridgeError.notConnected)
+
+        if connections.isEmpty {
+            extensionVersion = nil
+            extensionProtocolVersion = nil
         }
     }
 
@@ -580,7 +695,8 @@ actor WebSocketBridge {
     }
 
     private func isKnownConnection(_ conn: NWConnection) -> Bool {
-        connection === conn || authenticatingConnection === conn
+        profileIDsByConnection[ObjectIdentifier(conn)] != nil
+            || authenticatingConnections.contains { $0 === conn }
     }
 
     private func handleTextMessage(_ data: Data, from conn: NWConnection) {
@@ -591,9 +707,7 @@ actor WebSocketBridge {
             case .rejectToken:
                 logger.warning("Auth token mismatch — closing connection")
                 conn.cancel()
-                if authenticatingConnection === conn {
-                    authenticatingConnection = nil
-                }
+                removeAuthenticating(conn)
             case .rejectProtocol(_, let received):
                 logger.warning("Bridge protocol mismatch: extension=\(received), server=\(MCPSafariProduct.bridgeProtocolVersion)")
                 sendAuthResponse([
@@ -606,12 +720,10 @@ actor WebSocketBridge {
             return
         }
 
-        guard connection === conn else {
+        guard profileIDsByConnection[ObjectIdentifier(conn)] != nil else {
             logger.warning("Closing unauthenticated WebSocket connection that sent non-auth traffic")
             conn.cancel()
-            if authenticatingConnection === conn {
-                authenticatingConnection = nil
-            }
+            removeAuthenticating(conn)
             return
         }
 
@@ -645,25 +757,35 @@ actor WebSocketBridge {
     }
 
     private func authenticate(_ conn: NWConnection, metadata: ExtensionMetadata) {
-        if let existing = connection, existing !== conn {
-            logger.info("Replacing authenticated extension connection")
+        let profileID = metadata.profileID
+
+        // Replace only this profile's own connection, which is a genuine reconnect.
+        // Evicting across profiles is what made two of them flap against each other.
+        if let existing = connections[profileID], existing !== conn {
+            logger.info("Replacing authenticated extension connection (profile \(profileID))")
+            profileIDsByConnection.removeValue(forKey: ObjectIdentifier(existing))
             existing.cancel()
-            drainPendingRequests(error: BridgeError.notConnected)
+            drainPendingRequests(for: existing, error: BridgeError.notConnected)
         }
 
-        connection = conn
+        connections[profileID] = conn
+        profileIDsByConnection[ObjectIdentifier(conn)] = profileID
+        metadataByProfile[profileID] = metadata
+        if !profileOrder.contains(profileID) {
+            profileOrder.append(profileID)
+        }
+
         extensionVersion = metadata.version
         extensionProtocolVersion = metadata.protocolVersion
         lastError = nil
-        if authenticatingConnection === conn {
-            authenticatingConnection = nil
-        }
+        removeAuthenticating(conn)
 
-        logger.info("Safari extension authenticated")
+        logger.info("Safari extension authenticated (profile \(profileID))")
         sendAuthResponse([
             "auth": "ok",
             "serverVersion": MCPSafariProduct.version,
             "protocolVersion": MCPSafariProduct.bridgeProtocolVersion,
+            "profile": profileID,
         ], to: conn)
     }
 

--- a/MCPServer/Tests/MCPSafariTests/ProfileConnectionTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/ProfileConnectionTests.swift
@@ -1,0 +1,209 @@
+import Foundation
+import Logging
+import Testing
+@testable import MCPSafari
+
+/// Safari runs a separate extension instance per profile, and every one of them
+/// authenticates against the same bridge. The bug in #54 lives entirely in how those
+/// live connections interact, so these drive real loopback WebSockets: a faked
+/// transport cannot reproduce one connection evicting another.
+struct ProfileConnectionTests {
+
+    // MARK: - Harness
+
+    /// Ports here sit above the extension's auto-scan range (8089-8098) so a running
+    /// Safari never dials them, and the token files `start()` writes are removed after.
+    private func withStartedBridge(
+        port: UInt16,
+        _ body: (WebSocketBridge, UInt16) async throws -> Void
+    ) async throws {
+        let bridge = try WebSocketBridge(
+            port: port,
+            logger: Logger(label: "ProfileConnectionTests")
+        )
+        await bridge.start()
+        let boundPort = await bridge.port
+
+        do {
+            try await body(bridge, boundPort)
+        } catch {
+            await bridge.stop()
+            removeTokenFile(for: boundPort)
+            throw error
+        }
+
+        await bridge.stop()
+        removeTokenFile(for: boundPort)
+    }
+
+    private func removeTokenFile(for port: UInt16) {
+        for root in WebSocketBridge.tokenRootURLs {
+            let path = root.appendingPathComponent("tokens").appendingPathComponent(String(port))
+            try? FileManager.default.removeItem(at: path)
+        }
+    }
+
+    /// Connects and completes the handshake, returning the server's auth reply.
+    @discardableResult
+    private func authenticate(
+        port: UInt16,
+        token: String,
+        profileId: String?,
+        task: URLSessionWebSocketTask
+    ) async throws -> [String: Any] {
+        task.resume()
+
+        var handshake: [String: Any] = [
+            "auth": token,
+            "extensionVersion": "0.3.1",
+            "protocolVersion": MCPSafariProduct.bridgeProtocolVersion,
+        ]
+        if let profileId { handshake["profileId"] = profileId }
+
+        let payload = try JSONSerialization.data(withJSONObject: handshake)
+        try await task.send(.string(String(decoding: payload, as: UTF8.self)))
+
+        guard case let .string(reply) = try await task.receive(),
+              let parsed = try JSONSerialization.jsonObject(with: Data(reply.utf8)) as? [String: Any]
+        else {
+            throw BridgeTestError.unexpectedReply
+        }
+
+        return parsed
+    }
+
+    private func makeTask(port: UInt16) -> URLSessionWebSocketTask {
+        URLSession.shared.webSocketTask(with: URL(string: "ws://127.0.0.1:\(port)")!)
+    }
+
+    /// A ping round-trip is the only honest liveness check: a cancelled connection
+    /// fails it, whereas simply not receiving anything proves nothing.
+    private func isAlive(_ task: URLSessionWebSocketTask) async -> Bool {
+        await withCheckedContinuation { continuation in
+            nonisolated(unsafe) var resumed = false
+            task.sendPing { error in
+                guard !resumed else { return }
+                resumed = true
+                continuation.resume(returning: error == nil)
+            }
+        }
+    }
+
+    private enum BridgeTestError: Error {
+        case unexpectedReply
+    }
+
+    // MARK: - Tests
+
+    @Test func twoProfilesStayConnectedInsteadOfEvictingEachOther() async throws {
+        try await withStartedBridge(port: 8131) { bridge, port in
+            let token = await bridge.authToken
+
+            let personal = makeTask(port: port)
+            let work = makeTask(port: port)
+
+            let personalReply = try await authenticate(
+                port: port, token: token, profileId: "default", task: personal
+            )
+            let workReply = try await authenticate(
+                port: port, token: token, profileId: "WORK-UUID", task: work
+            )
+
+            #expect(personalReply["auth"] as? String == "ok")
+            #expect(workReply["auth"] as? String == "ok")
+            #expect(workReply["profile"] as? String == "WORK-UUID")
+
+            // The regression: the second handshake used to cancel the first.
+            #expect(await isAlive(personal))
+            #expect(await isAlive(work))
+
+            let status = await bridge.status()
+            #expect(status.bridge == .authenticated)
+            #expect(status.profiles.map(\.id) == ["default", "WORK-UUID"])
+            #expect(status.profiles.map(\.index) == [0, 1])
+
+            personal.cancel()
+            work.cancel()
+        }
+    }
+
+    @Test func aProfileReconnectingReplacesOnlyItsOwnConnection() async throws {
+        try await withStartedBridge(port: 8132) { bridge, port in
+            let token = await bridge.authToken
+
+            let work = makeTask(port: port)
+            let personal = makeTask(port: port)
+            try await authenticate(port: port, token: token, profileId: "WORK-UUID", task: work)
+            try await authenticate(port: port, token: token, profileId: "default", task: personal)
+
+            // The same profile dialling in again is a genuine reconnect, so replacing
+            // its predecessor is correct. The other profile must not notice.
+            let workAgain = makeTask(port: port)
+            let reply = try await authenticate(
+                port: port, token: token, profileId: "WORK-UUID", task: workAgain
+            )
+            #expect(reply["auth"] as? String == "ok")
+
+            #expect(await isAlive(personal))
+            #expect(await isAlive(workAgain))
+
+            let status = await bridge.status()
+            #expect(status.profiles.count == 2)
+            // The index survives the reconnect, so a handle stays meaningful.
+            #expect(status.profiles.first { $0.id == "WORK-UUID" }?.index == 0)
+
+            work.cancel()
+            personal.cancel()
+            workAgain.cancel()
+        }
+    }
+
+    @Test func aProfileDisconnectingLeavesTheOthersConnected() async throws {
+        try await withStartedBridge(port: 8133) { bridge, port in
+            let token = await bridge.authToken
+
+            let personal = makeTask(port: port)
+            let work = makeTask(port: port)
+            try await authenticate(port: port, token: token, profileId: "default", task: personal)
+            try await authenticate(port: port, token: token, profileId: "WORK-UUID", task: work)
+
+            work.cancel(with: .goingAway, reason: nil)
+
+            // Closing is reported through Network.framework, so poll rather than
+            // assume the teardown has landed by the next line.
+            var remaining = await bridge.status().profiles
+            for _ in 0..<50 where remaining.count > 1 {
+                try await Task.sleep(for: .milliseconds(20))
+                remaining = await bridge.status().profiles
+            }
+
+            #expect(remaining.map(\.id) == ["default"])
+            #expect(await bridge.isConnected)
+            #expect(await isAlive(personal))
+
+            personal.cancel()
+        }
+    }
+
+    @Test func anExtensionThatSendsNoProfileCountsAsTheDefault() async throws {
+        // Builds predating profile support send no profileId at all, and Safari sends
+        // none for the default profile. Both have to keep working unchanged.
+        let legacy = Data(#"{"auth":"secret","extensionVersion":"0.3.0","protocolVersion":1}"#.utf8)
+        #expect(
+            BridgeHandshake.decision(for: legacy, expectedToken: "secret")
+                == .accept(.init(version: "0.3.0", protocolVersion: 1, profileID: "default"))
+        )
+
+        let blank = Data(#"{"auth":"secret","profileId":"   "}"#.utf8)
+        #expect(
+            BridgeHandshake.decision(for: blank, expectedToken: "secret")
+                == .accept(.init(version: nil, protocolVersion: nil, profileID: "default"))
+        )
+
+        let named = Data(#"{"auth":"secret","profileId":"WORK-UUID"}"#.utf8)
+        #expect(
+            BridgeHandshake.decision(for: named, expectedToken: "secret")
+                == .accept(.init(version: nil, protocolVersion: nil, profileID: "WORK-UUID"))
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ For ports outside the default range, add them manually in the extension popup or
 }
 ```
 
+### Safari Profiles
+
+Safari runs a separate instance of the extension in every profile it is enabled for, each with its own background page and its own tabs. All of them connect to the same server. The server keeps one connection per profile and lists them under `profiles` in `status`.
+
+Tool calls drive a single profile: the default one when it is connected, otherwise the first to connect. Naming a profile in a tool call is not supported yet, so if you want to automate a non-default profile, turn the extension off in the profiles you are not driving. Safari exposes no profile *name* to extensions, so `status` identifies profiles by the opaque UUID Safari assigns them.
+
 ### CLI Options
 
 | Flag | Description |

--- a/Tests/ExtensionBackgroundTests.mjs
+++ b/Tests/ExtensionBackgroundTests.mjs
@@ -16,7 +16,7 @@ const popupHTML = readFileSync(
     "utf8"
 );
 
-function backgroundHarness(initialTokens) {
+function backgroundHarness(initialTokens, { profile } = {}) {
     const tokenMap = new Map(Object.entries(initialTokens));
     const sockets = [];
     const timers = [];
@@ -30,10 +30,11 @@ function backgroundHarness(initialTokens) {
         constructor(url) {
             this.url = url;
             this.readyState = FakeWebSocket.CONNECTING;
+            this.sent = [];
             sockets.push(this);
         }
 
-        send() {}
+        send(frame) { this.sent.push(frame); }
     }
 
     const browser = {
@@ -46,7 +47,10 @@ function backgroundHarness(initialTokens) {
             onMessage: { addListener: (listener) => runtimeListeners.push(listener) },
             sendNativeMessage: async () => {
                 nativeMessageCount++;
-                return { tokens: Object.fromEntries(tokenMap) };
+                const response = { tokens: Object.fromEntries(tokenMap) };
+                // The appex omits this for extension builds without profile support.
+                if (profile !== undefined) response.profile = profile;
+                return response;
             },
         },
         storage: {
@@ -72,6 +76,13 @@ function backgroundHarness(initialTokens) {
 
     return {
         evaluate: (source) => vm.runInContext(source, context),
+        /// Returns the handshake frame the extension sends on connect.
+        openLatestSocket() {
+            const socket = sockets.at(-1);
+            socket.readyState = FakeWebSocket.OPEN;
+            socket.onopen();
+            return JSON.parse(socket.sent.at(-1));
+        },
         failLatestSocket() {
             const socket = sockets.at(-1);
             socket.readyState = 3;
@@ -105,6 +116,25 @@ test("unchanged stale tokens stop reconnecting until their value changes", async
     await harness.evaluate("loadAuthTokens()");
     assert.equal(harness.evaluate("connections.has(8091)"), true);
     assert.equal(harness.sockets.length, 5);
+});
+
+test("the handshake carries the Safari profile the appex reported", async () => {
+    // Safari runs one instance of the extension per profile, all reading the same
+    // token. Without this the server cannot tell them apart and evicts one for the
+    // other, which is what made a two-profile setup flap.
+    const harness = backgroundHarness({ 8091: "current-token" }, { profile: "WORK-UUID" });
+    await settle();
+
+    const handshake = harness.openLatestSocket();
+    assert.equal(handshake.profileId, "WORK-UUID");
+    assert.equal(handshake.auth, "current-token");
+});
+
+test("an appex that reports no profile leaves the handshake on the default", async () => {
+    const harness = backgroundHarness({ 8091: "current-token" });
+    await settle();
+
+    assert.equal(harness.openLatestSocket().profileId, "default");
 });
 
 test("popup status polling does not restart disconnected ports", async () => {


### PR DESCRIPTION
Safari runs a separate instance of the extension in every profile, and all of them read the same token and dial the same port. `WebSocketBridge` held a single connection and cancelled the incumbent on every successful handshake, so two profiles evicted each other in a reconnect loop. That left a two-profile setup unusable even for the profile being driven.

The app extension already read `SFExtensionProfileKey` and only logged it. It now returns the value, `background.js` sends it in the auth handshake, and the bridge keys connections by profile, so a handshake replaces only that profile's own connection. Pending requests drain per connection, so one profile dropping no longer fails another's in-flight work.

An extension that sends no profile counts as the default, so there's no protocol bump. Tool calls still drive one profile, the default when it's connected, and `status` lists the rest. Profile targeting is still to come.

Refs #54