### PR TITLE
chore: bump app, extension, and server to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.3.1] - 2026-09-10
 ### Added
-- `screenshot` accepts `uid` or `selector` to capture one element plus `padding` CSS px of context, and `scale` to shrink the PNG; the result says which viewport CSS px the image covers.
+- `screenshot` accepts `uid` or `selector` to capture one element plus `padding` CSS px of context, and `scale` to shrink the PNG; the result says which viewport CSS px the image covers. A target inside an iframe is refused with `invalid_input`, because the capture covers the top-level viewport while a subframe measures its elements against its own, so cropping to that rect would return a confident picture of the wrong region.
 
 ### Bug Fixes
 - Safari profiles no longer fight over the extension connection. Safari runs a separate instance of the extension in each profile, with its own background page and its own storage, and every instance reads the same token and dials the same port. The bridge held a single connection, so each instance evicted the one before it and the evicted instance reconnected, which left a two-profile setup connecting and disconnecting in a loop rather than working, including for the profile being driven. The bridge now holds one connection per profile, identified by the profile Safari reports to the app extension. Tool calls still drive one profile, the default when it is connected, and `status` lists every connected profile so the others are visible rather than silently dropped. Targeting a specific profile is not supported yet.

--- a/MCPSafari/MCPSafari Extension/Resources/manifest.json
+++ b/MCPSafari/MCPSafari Extension/Resources/manifest.json
@@ -4,7 +4,7 @@
 
     "name": "__MSG_extension_name__",
     "description": "__MSG_extension_description__",
-    "version": "0.3.0",
+    "version": "0.3.1",
 
     "icons": {
         "48": "images/icon-48.png",

--- a/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
+++ b/MCPSafari/MCPSafari.xcodeproj/project.pbxproj
@@ -378,7 +378,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -393,7 +393,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -414,7 +414,7 @@
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "MCPSafari Extension/MCPSafari Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -429,7 +429,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -572,7 +572,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -587,7 +587,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -613,7 +613,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -628,7 +628,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -652,11 +652,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -673,11 +673,11 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -693,10 +693,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;
@@ -712,10 +712,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEVELOPMENT_TEAM = 3G4T4PCPZJ;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.epistates.MCPSafariUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = NO;

--- a/MCPServer/Sources/mcp-safari/Diagnostics.swift
+++ b/MCPServer/Sources/mcp-safari/Diagnostics.swift
@@ -69,7 +69,7 @@ func parseCommand(
 let logLevelUsage = "Use trace, debug, info, notice, warning, error, or critical."
 
 enum MCPSafariProduct {
-    static let version = "0.3.0"
+    static let version = "0.3.1"
     static let bridgeProtocolVersion = 1
     static let extensionBundleIdentifier = "com.epistates.MCPSafari.Extension"
 }

--- a/MCPServer/Tests/MCPSafariTests/BridgeStatusTests.swift
+++ b/MCPServer/Tests/MCPSafariTests/BridgeStatusTests.swift
@@ -59,16 +59,18 @@ struct BridgeStatusTests {
             logger: Logger(label: "BridgeStatusTests")
         )
         let token = await bridge.authToken
-        let incompatible = Data(#"{"auth":"\#(token)","extensionVersion":"0.3.0","protocolVersion":2}"#.utf8)
+        // Same reason as above: not a real release, so this cannot read as a
+        // shipped version being refused.
+        let incompatible = Data(#"{"auth":"\#(token)","extensionVersion":"99.0.0","protocolVersion":2}"#.utf8)
 
         #expect(
             await bridge.handshakeDecision(for: incompatible)
-                == .rejectProtocol(extensionVersion: "0.3.0", protocolVersion: 2)
+                == .rejectProtocol(extensionVersion: "99.0.0", protocolVersion: 2)
         )
 
         let status = await bridge.status()
         #expect(status.bridge == .disconnected)
-        #expect(status.extensionVersion == "0.3.0")
+        #expect(status.extensionVersion == "99.0.0")
         #expect(status.extensionProtocolVersion == 2)
         #expect(status.protocolVersion == MCPSafariProduct.bridgeProtocolVersion)
         #expect(status.lastError?.code == "protocol_version_mismatch")


### PR DESCRIPTION
Bumps `MARKETING_VERSION`, `CURRENT_PROJECT_VERSION`, the extension manifest, and the server constant to 0.3.1, and closes the 0.3.1 CHANGELOG section.

Also moves the protocol-mismatch test in `BridgeStatusTests` off `0.3.0`. That version is shipped now, so the assertion read as though the release itself was being refused. It uses the same placeholder as the sibling test above it, which was moved for exactly this reason during the 0.3.0 bump.

Verified: release build, 65 Swift tests, 138 node tests, Xcode build, and a stdio handshake reporting `0.3.1` with 27 tools.